### PR TITLE
Fix to https://jira.mongodb.org/browse/SPARK-103.

### DIFF
--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
@@ -21,7 +21,7 @@ import java.util
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
-import org.bson.{BsonDocument, BsonValue}
+import org.bson.{BsonDocument, BsonValue, BsonInt32}
 import com.mongodb.MongoCommandException
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.model.{Aggregates, Projections, Sorts}
@@ -81,7 +81,7 @@ class MongoSamplePartitioner extends MongoPartitioner {
         val samplesPerPartition = partitionerOptions.getOrElse(samplesPerPartitionProperty, DefaultSamplesPerPartition).toInt
 
         val count = results.getNumber("count").longValue()
-        val avgObjSizeInBytes = results.getNumber("avgObjSize").longValue()
+        val avgObjSizeInBytes = results.getNumber("avgObjSize", new BsonInt32(1)).longValue()
         val numDocumentsPerPartition: Int = math.floor(partitionSizeInBytes.toFloat / avgObjSizeInBytes).toInt
         val numberOfSamples = math.floor(samplesPerPartition * count / numDocumentsPerPartition.toFloat).toInt
 


### PR DESCRIPTION
Add a default value of 1 for an optional collstat result key, so partitioner will fallback to only one partition when collection is empty