### PR TITLE
More examples for reading & writing dataframe

### DIFF
--- a/doc/4-pyspark.md
+++ b/doc/4-pyspark.md
@@ -47,6 +47,18 @@ root
  |-- age: integer (nullable = true)
  |-- name: string (nullable = true)
 ```
+Alternatively, you can specify the database and collection while reading the dataframe:
+
+```python
+df = spark.read.format("com.mongodb.spark.sql.DefaultSource")\
+    .option("spark.mongodb.input.uri", "mongodb://<host>:<port>/<db>.<collection>").load()
+```
+And to write a dataframe to a collection:
+
+```python
+df.write.format("com.mongodb.spark.sql.DefaultSource")\
+    .option("spark.mongodb.output.uri", "mongodb://<host>:<port>/<db>.<collection>").save()
+```
 
 ### SQL
 


### PR DESCRIPTION
Adding more examples to showcase reading & writing dataframes.
The input & output URI can be specified at the time of reading / writing dataframe instead of starting pyspark