### PR TITLE
SPARK-81 Set allow disk use to true for all aggregations

### DIFF
--- a/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/MongoRDD.scala
@@ -163,6 +163,7 @@ class MongoRDD[D: ClassTag](
       .withReadConcern(readConfig.readConcern)
       .withReadPreference(readConfig.readPreference)
       .aggregate(partitionPipeline.asJava)
+      .allowDiskUse(true)
       .iterator
   }
 

--- a/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
+++ b/src/main/scala/com/mongodb/spark/rdd/partitioner/MongoSamplePartitioner.scala
@@ -94,7 +94,7 @@ class MongoSamplePartitioner extends MongoPartitioner {
                   Aggregates.sample(numberOfSamples),
                   Aggregates.project(Projections.include(partitionKey)),
                   Aggregates.sort(Sorts.ascending(partitionKey))
-                ).asJava).into(new util.ArrayList[BsonDocument]()).asScala
+                ).asJava).allowDiskUse(true).into(new util.ArrayList[BsonDocument]()).asScala
             })
             samples.zipWithIndex.collect { case (field, i) if i % samplesPerPartition == 0 => field.get("_id") }
         }


### PR DESCRIPTION
This is the same fix as in [7b628edcbbdb9affca11ea7df810085ff987cd7e](https://github.com/mongodb/mongo-spark/commit/7b628edcbbdb9affca11ea7df810085ff987cd7e) to fix [SPARK-81]( https://jira.mongodb.org/browse/SPARK-81).

This has not yet been fixed for Spark versions < 2.0
