### PR TITLE
SPARK-133: Add detection for MapType

### DIFF
--- a/doc/2-configuring.md
+++ b/doc/2-configuring.md
@@ -18,18 +18,20 @@ In the Spark API there are some methods that accept extra options in the form of
 
 The following options are available:
 
-Property name              | Description                                                       | Default value
----------------------------|-------------------------------------------------------------------|--------------------
-uri                        | The connection string                                             |
-database                   | The database name to read data from                               |
-collection                 | The collection name to read data from                             |
-localThreshold             | The threshold for choosing a server from multiple MongoDB servers | 15 ms
-readPreference.name        | The name of the `ReadPreference` to use                           | Primary
-readPreference.tagSets     | The `ReadPreference` TagSets to use                               |
-readConcern.level          | The `ReadConcern` level to use                                    |
-sampleSize                 | The sample size to use when inferring the schema                  | 1000
-partitioner                | The class name of the partitioner to use to partition the data    | MongoDefaultPartitioner
-registerSQLHelperFunctions | Register helper methods for unsupported Mongo Datatypes           | false
+Property name                    | Description                                                                     | Default value
+---------------------------------|---------------------------------------------------------------------------------|--------------------
+uri                              | The connection string                                                           |
+database                         | The database name to read data from                                             |
+collection                       | The collection name to read data from                                           |
+localThreshold                   | The threshold for choosing a server from multiple MongoDB servers               | 15 ms
+readPreference.name              | The name of the `ReadPreference` to use                                         | Primary
+readPreference.tagSets           | The `ReadPreference` TagSets to use                                             |
+readConcern.level                | The `ReadConcern` level to use                                                  |
+sampleSize                       | The sample size to use when inferring the schema                                | 1000
+partitioner                      | The class name of the partitioner to use to partition the data                  | MongoDefaultPartitioner
+registerSQLHelperFunctions       | Register helper methods for unsupported Mongo Datatypes                         | false
+schemaInfer.mapTypes.enabled     | Enable MapType detection in schema infer step                                   | true
+schemaInfer.mapTypes.minimumKeys | The minimum number of keys a StructType needs to have to be inferred as MapType | 250
 
 -----
 **Note**: When setting input configurations in the `SparkConf` then the prefix `spark.mongodb.input.` is required.

--- a/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoInputConfig.scala
@@ -125,4 +125,23 @@ trait MongoInputConfig extends MongoCompanionConfig {
    */
   val registerSQLHelperFunctions = "registerSQLHelperFunctions".toLowerCase()
 
+  /**
+   * The schemaInfer MapType enabled property
+   *
+   * A boolean flag to enable or disable MapType infer.
+   * If this flag is enabled, large compatible struct types will be inferred to a MapType instead.
+   *
+   * Default: `true`
+   */
+  val schemaInferMapTypeEnabledProperty = "schemaInfer.mapTypes.enabled".toLowerCase
+
+  /**
+   * The schemaInfer MapType minimum keys property
+   *
+   * The minimum keys property controls how large a struct must be before a MapType should be inferred.
+   *
+   * Default: `250`
+   */
+  val schemaInferMapTypeMinimumKeysProperty = "schemaInfer.mapTypes.minimumKeys".toLowerCase
+
 }

--- a/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
@@ -61,6 +61,7 @@ class DefaultSource extends DataSourceRegister with RelationProvider with Schema
     createRelation(sqlContext, parameters, Some(schema))
 
   private def createRelation(sqlContext: SQLContext, parameters: Map[String, String], structType: Option[StructType]): BaseRelation = {
+    val readConfig = ReadConfig(sqlContext.sparkContext.getConf, parameters)
     val rdd = pipelinedRdd(
       MongoSpark.builder()
         .sparkSession(sqlContext.sparkSession)

--- a/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/mongodb/spark/sql/DefaultSource.scala
@@ -61,7 +61,6 @@ class DefaultSource extends DataSourceRegister with RelationProvider with Schema
     createRelation(sqlContext, parameters, Some(schema))
 
   private def createRelation(sqlContext: SQLContext, parameters: Map[String, String], structType: Option[StructType]): BaseRelation = {
-    val readConfig = ReadConfig(sqlContext.sparkContext.getConf, parameters)
     val rdd = pipelinedRdd(
       MongoSpark.builder()
         .sparkSession(sqlContext.sparkSession)

--- a/src/test/scala/com/mongodb/spark/config/ReadConfigSpec.scala
+++ b/src/test/scala/com/mongodb/spark/config/ReadConfigSpec.scala
@@ -49,6 +49,8 @@ class ReadConfigSpec extends FlatSpec with Matchers {
     readConfig.localThreshold should equal(expectedReadConfig.localThreshold)
     readConfig.readPreferenceConfig should equal(expectedReadConfig.readPreferenceConfig)
     readConfig.readConcernConfig should equal(expectedReadConfig.readConcernConfig)
+    readConfig.schemaInferMapTypesMinimumKeys should equal(expectedReadConfig.schemaInferMapTypesMinimumKeys)
+    readConfig.schemaInferMapTypesEnabled should equal(expectedReadConfig.schemaInferMapTypesEnabled)
   }
 
   it should "use the URI for default values" in {
@@ -82,7 +84,9 @@ class ReadConfigSpec extends FlatSpec with Matchers {
     val expectedReadConfig = ReadConfig("db", "collection", Some("mongodb://localhost/"), 200, MongoSplitVectorPartitioner,
       Map("partitioneroptions.partitionsizemb" -> "15"), 0,
       ReadPreferenceConfig(ReadPreference.secondaryPreferred(new TagSet(List(new Tag("dc", "east"), new Tag("use", "production")).asJava))),
-      ReadConcernConfig(ReadConcern.MAJORITY))
+      ReadConcernConfig(ReadConcern.MAJORITY),
+      schemaInferMapTypesEnabled = false,
+      schemaInferMapTypesMinimumKeys = 999)
 
     val readConfig = defaultReadConfig.withOptions(expectedReadConfig.asOptions)
 
@@ -95,6 +99,8 @@ class ReadConfigSpec extends FlatSpec with Matchers {
     readConfig.localThreshold should equal(expectedReadConfig.localThreshold)
     readConfig.readPreferenceConfig should equal(expectedReadConfig.readPreferenceConfig)
     readConfig.readConcernConfig should equal(expectedReadConfig.readConcernConfig)
+    readConfig.schemaInferMapTypesMinimumKeys should equal(expectedReadConfig.schemaInferMapTypesMinimumKeys)
+    readConfig.schemaInferMapTypesEnabled should equal(expectedReadConfig.schemaInferMapTypesEnabled)
   }
 
   it should "be able to create a map" in {
@@ -104,7 +110,9 @@ class ReadConfigSpec extends FlatSpec with Matchers {
         new TagSet(List(new Tag("dc", "east"), new Tag("use", "production")).asJava),
         new TagSet()
       ).asJava)),
-      ReadConcernConfig(ReadConcern.MAJORITY))
+      ReadConcernConfig(ReadConcern.MAJORITY),
+      schemaInferMapTypesEnabled = false,
+      schemaInferMapTypesMinimumKeys = 999)
 
     val expectedReadConfigMap = Map(
       "database" -> "dbName",
@@ -116,7 +124,9 @@ class ReadConfigSpec extends FlatSpec with Matchers {
       "readpreference.name" -> "secondaryPreferred",
       "readpreference.tagsets" -> """[{dc:"east",use:"production"},{}]""",
       "readconcern.level" -> "majority",
-      "samplesize" -> "200"
+      "samplesize" -> "200",
+      "schemainfer.maptypes.enabled" -> "false",
+      "schemainfer.maptypes.minimumkeys" -> "999"
     )
 
     readConfig.asOptions should equal(expectedReadConfigMap)

--- a/src/test/scala/com/mongodb/spark/sql/MongoInferSchemaSpec.scala
+++ b/src/test/scala/com/mongodb/spark/sql/MongoInferSchemaSpec.scala
@@ -17,16 +17,13 @@
 package com.mongodb.spark.sql
 
 import scala.collection.JavaConverters._
-
 import org.apache.spark.sql.types.DataTypes.{createArrayType, createStructField, createStructType}
-import org.apache.spark.sql.types.{ArrayType, DataTypes, StringType, StructField}
-
+import org.apache.spark.sql.types._
 import org.bson.conversions.Bson
 import org.bson.{BsonDocument, Document}
 import com.mongodb.MongoClient
 import com.mongodb.spark._
 import com.mongodb.spark.sql.types.BsonCompatibility
-
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class MongoInferSchemaSpec extends RequiresMongoDB with MongoDataGenerator with TableDrivenPropertyChecks {
@@ -189,6 +186,42 @@ class MongoInferSchemaSpec extends RequiresMongoDB with MongoDataGenerator with 
     forAll(conflictingSchemas) { documents =>
       sc.parallelize(documents.map(BsonDocument.parse)).saveToMongoDB()
       MongoInferSchema(sc) should equal(conflictSchema)
+      database.drop()
+    }
+  }
+
+  it should "detect fields with a MapType" in withSparkContext() { sc =>
+    val _idField: StructField = createStructField("_id", BsonCompatibility.ObjectId.structType, true)
+    val mapValueType: StructType = createStructType(Array(createStructField("a", IntegerType, true), createStructField("b", IntegerType, true)))
+    val mapType: MapType = DataTypes.createMapType(StringType, mapValueType, true)
+    val mapField: StructField = createStructField("map", mapType, true)
+    val expectedSchema = createStructType(Array(_idField, mapField))
+
+    val validKeyCount = 250
+
+    val validSchemas = Table(
+      "documents",
+      (1 to validKeyCount).map(i => "{map:{example" + i + ": {a: 1, b: 2}}}"),
+      (1 to validKeyCount).map(i => "{map:{example" + i + ": {a: 1}, example" + (i - 1) + ": {b: 2}}}")
+    )
+
+    forAll(validSchemas) { documents =>
+      sc.parallelize(documents.map(BsonDocument.parse)).saveToMongoDB()
+      MongoInferSchema(sc) should equal(expectedSchema)
+      database.drop()
+    }
+
+    val invalidKeyCount = 100
+    val invalidSchemas = Table(
+      "documents",
+      (1 to invalidKeyCount).map(i => "{map:{example" + i + ": {a: 1, b: 2}}}"),
+      (1 to invalidKeyCount).map(i => "{map:{example" + i + ": {a: 1}, example" + (i - 1) + ": {b: 2}}}"),
+      (1 to validKeyCount).map(i => "{map:{example" + i + ": {a: 1}, exampleAlt" + i + ": 1}}")
+    )
+
+    forAll(invalidSchemas) { documents =>
+      sc.parallelize(documents.map(BsonDocument.parse)).saveToMongoDB()
+      MongoInferSchema(sc) shouldNot equal(expectedSchema)
       database.drop()
     }
   }

--- a/src/test/scala/com/mongodb/spark/sql/MongoInferSchemaSpec.scala
+++ b/src/test/scala/com/mongodb/spark/sql/MongoInferSchemaSpec.scala
@@ -23,11 +23,11 @@ import org.bson.conversions.Bson
 import org.bson.{BsonDocument, Document}
 import com.mongodb.MongoClient
 import com.mongodb.spark._
+import com.mongodb.spark.config.ReadConfig
 import com.mongodb.spark.sql.types.BsonCompatibility
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class MongoInferSchemaSpec extends RequiresMongoDB with MongoDataGenerator with TableDrivenPropertyChecks {
-
   "MongoSchemaHelper" should "be able to infer the schema from simple types" in withSparkContext() { sc =>
     forAll(genSimpleDataTypes) { (datum: Seq[MongoDataType]) =>
       datum.foreach { data =>
@@ -190,7 +190,7 @@ class MongoInferSchemaSpec extends RequiresMongoDB with MongoDataGenerator with 
     }
   }
 
-  it should "detect fields with a MapType" in withSparkContext() { sc =>
+  it should "detect fields with a MapType and use " in withSparkContext() { sc =>
     val _idField: StructField = createStructField("_id", BsonCompatibility.ObjectId.structType, true)
     val mapValueType: StructType = createStructType(Array(createStructField("a", IntegerType, true), createStructField("b", IntegerType, true)))
     val mapType: MapType = DataTypes.createMapType(StringType, mapValueType, true)
@@ -222,6 +222,62 @@ class MongoInferSchemaSpec extends RequiresMongoDB with MongoDataGenerator with 
     forAll(invalidSchemas) { documents =>
       sc.parallelize(documents.map(BsonDocument.parse)).saveToMongoDB()
       MongoInferSchema(sc) shouldNot equal(expectedSchema)
+      database.drop()
+    }
+  }
+
+  it should "not detect fields with a MapType when detection is disabled" in withSparkContext() { sc =>
+    val _idField: StructField = createStructField("_id", BsonCompatibility.ObjectId.structType, true)
+    val mapValueType: StructType = createStructType(Array(createStructField("a", IntegerType, true), createStructField("b", IntegerType, true)))
+    val mapType: MapType = DataTypes.createMapType(StringType, mapValueType, true)
+    val mapField: StructField = createStructField("map", mapType, true)
+    val expectedSchema = createStructType(Array(_idField, mapField))
+
+    val keyCount = 250
+
+    val validSchemas = Table(
+      "documents",
+      (1 to keyCount).map(i => "{map:{example" + i + ": {a: 1, b: 2}}}"),
+      (1 to keyCount).map(i => "{map:{example" + i + ": {a: 1}, example" + (i - 1) + ": {b: 2}}}")
+    )
+
+    forAll(validSchemas) { documents =>
+      sc.parallelize(documents.map(BsonDocument.parse)).saveToMongoDB()
+      val rdd = MongoSpark
+        .builder()
+        .sparkContext(sc)
+        .readConfig(readConfig.copy(schemaInferMapTypesEnabled = false))
+        .build()
+        .toRDD[BsonDocument]()
+      MongoInferSchema(rdd) shouldNot equal(expectedSchema)
+      database.drop()
+    }
+  }
+
+  it should "not detect fields with a MapType when the minimum keys number was raised" in withSparkContext() { sc =>
+    val _idField: StructField = createStructField("_id", BsonCompatibility.ObjectId.structType, true)
+    val mapValueType: StructType = createStructType(Array(createStructField("a", IntegerType, true), createStructField("b", IntegerType, true)))
+    val mapType: MapType = DataTypes.createMapType(StringType, mapValueType, true)
+    val mapField: StructField = createStructField("map", mapType, true)
+    val expectedSchema = createStructType(Array(_idField, mapField))
+
+    val keyCount = 250
+
+    val validSchemas = Table(
+      "documents",
+      (1 to keyCount).map(i => "{map:{example" + i + ": {a: 1, b: 2}}}"),
+      (1 to keyCount).map(i => "{map:{example" + i + ": {a: 1}, example" + (i - 1) + ": {b: 2}}}")
+    )
+
+    forAll(validSchemas) { documents =>
+      sc.parallelize(documents.map(BsonDocument.parse)).saveToMongoDB()
+      val rdd = MongoSpark
+        .builder()
+        .sparkContext(sc)
+        .readConfig(readConfig.copy(schemaInferMapTypesMinimumKeys = 500)) // scalastyle:ignore
+        .build()
+        .toRDD[BsonDocument]()
+      MongoInferSchema(rdd) shouldNot equal(expectedSchema)
       database.drop()
     }
   }


### PR DESCRIPTION
As described in the Jira Issue https://jira.mongodb.org/browse/SPARK-133 I have added detection for MapTypes when a Struct grows over 250 keys. This should help people who use maps in their MongoDB documents.