### PR TITLE
invalid precision/scale inference

### DIFF
--- a/src/main/scala/com/mongodb/spark/sql/MongoInferSchema.scala
+++ b/src/main/scala/com/mongodb/spark/sql/MongoInferSchema.scala
@@ -245,7 +245,8 @@ object MongoInferSchema extends Logging {
       case BsonType.DB_POINTER            => BsonCompatibility.DbPointer.structType
       case BsonType.DECIMAL128 =>
         val bigDecimalValue = bsonValue.asDecimal128().decimal128Value().bigDecimalValue()
-        DataTypes.createDecimalType(bigDecimalValue.precision(), bigDecimalValue.scale())
+        val precision = Integer.max(bigDecimalValue.scale(), bigDecimalValue.precision())
+        DataTypes.createDecimalType(precision, bigDecimalValue.scale())
       case _ => ConflictType
     }
   }


### PR DESCRIPTION
Inference fails on values when there are zeroes followed by nonzeroes on one side of the decimal point and only zeroes on the other side.

ie, loading a collection with:
```
{
	"foo" : NumberDecimal("0.01")
}
```
yields:
```
Exception in thread "main" org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 8.0 failed 1 times, most recent failure: Lost task 0.0 in stage 8.0 (TID 11, localhost, executor driver): org.apache.spark.sql.AnalysisException: Decimal scale (2) cannot be greater than precision (1).;
	at org.apache.spark.sql.types.DecimalType.<init>(DecimalType.scala:45)
	at org.apache.spark.sql.types.DecimalType$.apply(DecimalType.scala:42)
	at org.apache.spark.sql.types.DataTypes.createDecimalType(DataTypes.java:123)
	at com.mongodb.spark.sql.MongoInferSchema$.com$mongodb$spark$sql$MongoInferSchema$$getDataType(MongoInferSchema.scala:248)
```


