### PR TITLE
[Spark][SQL]Add java spi for mongo.

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.mongodb.spark.sql.DefaultSource


### PR DESCRIPTION
Spark support custom data source connector and using java `spi` to register.
See at: https://github.com/databricks/spark-xml/blob/a0a8b15d940bdc91eb7d6d24e8fdc60baf33a2a5/src/main/scala/com/databricks/spark/xml/DefaultSource.scala#L38

See also https://github.com/databricks/spark-xml/blob/a0a8b15d940bdc91eb7d6d24e8fdc60baf33a2a5/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister

Spark original code contains some code of java `spi` as follows:
```
  def lookupDataSource(provider: String, conf: SQLConf): Class[_] = {
    val provider1 = backwardCompatibilityMap.getOrElse(provider, provider) match {
      case name if name.equalsIgnoreCase("orc") &&
          conf.getConf(SQLConf.ORC_IMPLEMENTATION) == "native" =>
        classOf[OrcFileFormat].getCanonicalName
      case name if name.equalsIgnoreCase("orc") &&
          conf.getConf(SQLConf.ORC_IMPLEMENTATION) == "hive" =>
        "org.apache.spark.sql.hive.orc.OrcFileFormat"
      case name => name
    }
    val provider2 = s"$provider1.DefaultSource"
    val loader = Utils.getContextOrSparkClassLoader
    val serviceLoader = ServiceLoader.load(classOf[DataSourceRegister], loader)

    try {
      serviceLoader.asScala.filter(_.shortName().equalsIgnoreCase(provider1)).toList match {
```

But `mongo` connector still not implement the function.
So I add this `spi` configuration.