### PR TITLE
Added replace and update support for RDD's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Mongo Spark Connector Changelog
 
+## 3.0.1
+  * [[SPARK-280](https://jira.mongodb.org/browse/SPARK-280)] Support replace and updates from RDD's that include an `_id`. 
+    Use `forceInsert` to keep existing behaviour.
+
 ## 3.0.0
   * [[SPARK-274](https://jira.mongodb.org/browse/SPARK-274)] Spark 3.0.0 support
   * [[SPARK-275](https://jira.mongodb.org/browse/SPARK-275)] Updated mongodb-driver-sync version to 4.0.4

--- a/src/main/scala/com/mongodb/spark/MongoSpark.scala
+++ b/src/main/scala/com/mongodb/spark/MongoSpark.scala
@@ -17,7 +17,7 @@
 package com.mongodb.spark
 
 import com.mongodb.client.MongoCollection
-import com.mongodb.client.model.{BulkWriteOptions, InsertManyOptions, InsertOneModel, ReplaceOneModel, ReplaceOptions, UpdateOneModel, UpdateOptions}
+import com.mongodb.client.model.{BulkWriteOptions, InsertOneModel, ReplaceOneModel, ReplaceOptions, UpdateOneModel, UpdateOptions}
 import com.mongodb.spark.DefaultHelper.DefaultsTo
 import com.mongodb.spark.config.{ReadConfig, WriteConfig}
 import com.mongodb.spark.rdd.MongoRDD
@@ -30,6 +30,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Dataset, Encoders, SQLContext, SparkSession}
+import org.bson.BsonDocumentWrapper.asBsonDocument
 import org.bson.conversions.Bson
 import org.bson.{BsonDocument, Document}
 
@@ -114,12 +115,28 @@ object MongoSpark {
    */
   def save[D: ClassTag](rdd: RDD[D], writeConfig: WriteConfig): Unit = {
     val mongoConnector = MongoConnector(writeConfig.asOptions)
+    val queryKeyList = BsonDocument.parse(writeConfig.shardKey.getOrElse("{_id: 1}")).keySet().asScala.toList
+
     rdd.foreachPartition(iter => if (iter.nonEmpty) {
-      mongoConnector.withCollectionDo(writeConfig, { collection: MongoCollection[D] =>
-        iter.grouped(writeConfig.maxBatchSize).foreach(batch => collection.insertMany(
-          batch.toList.asJava,
-          new InsertManyOptions().ordered(writeConfig.ordered)
-        ))
+      mongoConnector.withCollectionDo(writeConfig, { collection: MongoCollection[BsonDocument] =>
+        iter.grouped(writeConfig.maxBatchSize).foreach(batch => {
+          val requests = batch.map(data => {
+            val doc = asBsonDocument(data, collection.getCodecRegistry)
+            if (!writeConfig.forceInsert && queryKeyList.forall(doc.containsKey(_))) {
+              val queryDocument = new BsonDocument()
+              queryKeyList.foreach(key => queryDocument.append(key, doc.get(key)))
+              if (writeConfig.replaceDocument) {
+                new ReplaceOneModel[BsonDocument](queryDocument, doc, new ReplaceOptions().upsert(true))
+              } else {
+                queryDocument.keySet().asScala.foreach(doc.remove(_))
+                new UpdateOneModel[BsonDocument](queryDocument, new BsonDocument("$set", doc), new UpdateOptions().upsert(true))
+              }
+            } else {
+              new InsertOneModel[BsonDocument](doc)
+            }
+          })
+          collection.bulkWrite(requests.toList.asJava, new BulkWriteOptions().ordered(writeConfig.ordered))
+        })
       })
     })
   }
@@ -148,37 +165,8 @@ object MongoSpark {
    * @since 1.1.0
    */
   def save[D](dataset: Dataset[D], writeConfig: WriteConfig): Unit = {
-    val mongoConnector = MongoConnector(writeConfig.asOptions)
-    val dataSet = dataset.toDF()
-    val mapper = rowToDocumentMapper(dataSet.schema, writeConfig.extendedBsonTypes)
-    val documentRdd: RDD[BsonDocument] = dataSet.rdd.map(row => mapper(row))
-    val fieldNames = dataset.schema.fieldNames.toList
-    val queryKeyList = BsonDocument.parse(writeConfig.shardKey.getOrElse("{_id: 1}")).keySet().asScala.toList
-
-    if (writeConfig.forceInsert || !queryKeyList.forall(fieldNames.contains(_))) {
-      MongoSpark.save(documentRdd, writeConfig)
-    } else {
-      documentRdd.foreachPartition(iter => if (iter.nonEmpty) {
-        mongoConnector.withCollectionDo(writeConfig, { collection: MongoCollection[BsonDocument] =>
-          iter.grouped(writeConfig.maxBatchSize).foreach(batch => {
-            val requests = batch.map(doc =>
-              if (queryKeyList.forall(doc.containsKey(_))) {
-                val queryDocument = new BsonDocument()
-                queryKeyList.foreach(key => queryDocument.append(key, doc.get(key)))
-                if (writeConfig.replaceDocument) {
-                  new ReplaceOneModel[BsonDocument](queryDocument, doc, new ReplaceOptions().upsert(true))
-                } else {
-                  queryDocument.keySet().asScala.foreach(doc.remove(_))
-                  new UpdateOneModel[BsonDocument](queryDocument, new BsonDocument("$set", doc), new UpdateOptions().upsert(true))
-                }
-              } else {
-                new InsertOneModel[BsonDocument](doc)
-              })
-            collection.bulkWrite(requests.toList.asJava, new BulkWriteOptions().ordered(writeConfig.ordered))
-          })
-        })
-      })
-    }
+    val mapper = rowToDocumentMapper(dataset.schema, writeConfig.extendedBsonTypes)
+    save(dataset.toDF().rdd.map(row => mapper(row)), writeConfig)
   }
 
   /**

--- a/src/test/scala/com/mongodb/spark/MongoRDDSpec.scala
+++ b/src/test/scala/com/mongodb/spark/MongoRDDSpec.scala
@@ -160,4 +160,13 @@ class MongoRDDSpec extends RequiresMongoDB {
       .withPipeline(Seq(Document.parse("{$match: {str: 'FOO'}}"))).count() should equal(2)
   }
 
+  it should "support replacing existing documents" in withSparkContext() { sc =>
+    sc.parallelize((1 to 100).map(i => Document.parse(s"{_id: $i, number: $i}"))).saveToMongoDB()
+    sc.loadFromMongoDB().count() shouldBe 100
+    sc.loadFromMongoDB().withPipeline(List(Document.parse("{$match: { number: {$gt: 100}}}"))).count() shouldBe 0
+
+    sc.parallelize((1 to 100).map(i => Document.parse(s"{_id: $i, number: ${i + 1000}}"))).saveToMongoDB()
+    sc.loadFromMongoDB().count() shouldBe 100
+    sc.loadFromMongoDB().withPipeline(List(Document.parse("{$match: { number: {$gt: 100}}}"))).count() shouldBe 100
+  }
 }


### PR DESCRIPTION
If the RDD contains the `_id` field or the shard key then
when saving values replace and upserts will be used.

Use `WriteConfig.forceInserts` to use inserts rather than upserts.

SPARK-280