### PR TITLE
SPARK-324 - MongoSpark SAVE API which accepts MongoConnector instance as argument

### DIFF
--- a/project/scalastyle-config.xml
+++ b/project/scalastyle-config.xml
@@ -95,7 +95,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[30]]></parameter>
+   <parameter name="maxMethods"><![CDATA[35]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>

--- a/src/main/scala/com/mongodb/spark/MongoSpark.scala
+++ b/src/main/scala/com/mongodb/spark/MongoSpark.scala
@@ -106,15 +106,25 @@ object MongoSpark {
    */
   def save[D: ClassTag](rdd: RDD[D]): Unit = save(rdd, WriteConfig(rdd.sparkContext))
 
-  /**
+/**
    * Save data to MongoDB
    *
    * @param rdd the RDD data to save to MongoDB
    * @param writeConfig the writeConfig
    * @tparam D the type of the data in the RDD
    */
-  def save[D: ClassTag](rdd: RDD[D], writeConfig: WriteConfig): Unit = {
-    val mongoConnector = MongoConnector(writeConfig.asOptions)
+  def save[D: ClassTag](rdd: RDD[D], writeConfig: WriteConfig): Unit = 
+    save(rdd, writeConfig, MongoConnector(writeConfig.asOptions))
+
+  /**
+   * Save data to MongoDB
+   *
+   * @param rdd the RDD data to save to MongoDB
+   * @param writeConfig the writeConfig
+   * @param mongoConnector the mongoConnector
+   * @tparam D the type of the data in the RDD
+   */
+  def save[D: ClassTag](rdd: RDD[D], writeConfig: WriteConfig, mongoConnector: MongoConnector): Unit = {
     val queryKeyList = BsonDocument.parse(writeConfig.shardKey.getOrElse("{_id: 1}")).keySet().asScala.toList
 
     rdd.foreachPartition(iter => if (iter.nonEmpty) {


### PR DESCRIPTION
PR for SPARK-324: MongoSpark SAVE API which accepts MongoConnector instance as argument

- Added a new save method in MongoSpark.scala which also accepts MongoConnector instance.
- Increased maxMethods count to 35 since MongoSpark now has over 30 methods.