### PR TITLE
Potential security vulnerability in the zstd C library.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ repositories {
 extra.apply {
     set("annotationsVersion", "22.0.0")
     set("mongodbDriverVersion", "[4.5.0,4.5.99)")
-    set("sparkVersion", "3.1.2")
+    set("sparkVersion", "3.2.0")
 
     // Testing dependencies
     set("junitJupiterVersion", "5.7.2")


### PR DESCRIPTION
Hi, @rozza , I'd like to report a vulnerable dependency in **org.mongodb.spark:mongo-spark-connector_2.12:3.0.2**.
### Issue Description
I noticed that **org.mongodb.spark:mongo-spark-connector_2.12:3.0.2** directly depends on **org.apache.spark:spark-core_2.12:3.0.0** in the [pom](https://repo1.maven.org/maven2/org/mongodb/spark/mongo-spark-connector_2.12/3.0.2/mongo-spark-connector_2.12-3.0.2.pom). However, as shown in the following dependency graph, **org.apache.spark:spark-core_2.12:3.0.0** sufferes from the vulnerability which the C library **zstd(version:1.4.4)** exposed: [CVE-2019-11922](https://nvd.nist.gov/vuln/detail/CVE-2019-11922).
### Dependency Graph between Java and Shared Libraries
![image (12)](https://user-images.githubusercontent.com/103260963/163416830-4e3e24b6-b9ef-423b-9e95-e6b270aedf7f.png)
### Suggested Vulnerability Patch Versions
**org.apache.spark:spark-core_2.12:3.2.0** (**>=3.2.0**) has upgraded this vulnerable C library `zstd` to the patch version **1.5.0**.

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr