### PR TITLE
[SPARK-346] Fix convert date type to bson

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverter.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -124,7 +125,7 @@ public final class RowToBsonDocumentConverter implements Serializable {
       } else if (DataTypes.BooleanType.acceptsType(dataType)) {
         return new BsonBoolean((Boolean) data);
       } else if (DataTypes.DateType.acceptsType(dataType)) {
-        return new BsonDateTime(((Timestamp) data).getTime());
+        return new BsonDateTime(((Date) data).getTime());
       } else if (DataTypes.DoubleType.acceptsType(dataType)) {
         return new BsonDouble(((Number) data).doubleValue());
       } else if (DataTypes.FloatType.acceptsType(dataType)) {

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.bson.BsonArray;
+import org.bson.BsonDateTime;
 import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
 import org.bson.types.Decimal128;
@@ -77,6 +79,17 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
                     "decimalType",
                     DataTypes.createDecimalType(bigDecimal.precision(), bigDecimal.scale()),
                     true));
+    assertEquals(expected, CONVERTER.fromRow(row));
+  }
+
+  @Test
+  @DisplayName("test date types")
+  void testDateTypes() {
+    Date date = Date.valueOf("2022-05-01");
+    Row row =
+        new GenericRowWithSchema(
+            new Object[] {date}, new StructType().add("dateType", DataTypes.DateType, true));
+    BsonDocument expected = new BsonDocument("dateType", new BsonDateTime(date.getTime()));
     assertEquals(expected, CONVERTER.fromRow(row));
   }
 

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
 import java.sql.Timestamp;
 
 import org.apache.spark.sql.Row;
@@ -57,7 +58,7 @@ abstract class SchemaTest {
                   "abc".getBytes(StandardCharsets.UTF_8),
                   true,
                   (byte) 1,
-                  new Timestamp(3600000L),
+                  new Date(3600000L),
                   2.0,
                   3.0f,
                   5,


### PR DESCRIPTION
When I try to write a databricks data frame with `DateType` to mongodb, I got `Error: Cannot cast 2022-05-13 into a BsonValue. DateType has no matching BsonValue. Error: java.sql.Date cannot be cast to java.sql.Timestamp`

I found that the connector treats `DateType` as `jave.sql.Timestamp` during conversion, however, `DateType` should be `jave.sql.Date` and `jave.sql.Date` can't be casted as `jave.sql.Timestamp`

This PR fixes the `DateType` to bson conversion, and also adds a test case to ensure the conversion works as expected.