### PR TITLE
Updated MongoScanBuilder

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoSparkConnectorReadTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoSparkConnectorReadTest.java
@@ -153,22 +153,36 @@ class MongoSparkConnectorReadTest extends MongoSparkConnectorTestCase {
   void testWhereFiltersAreConverted() {
     BsonDocument allTypesDocument = BsonDocument.parse(BSON_DOCUMENT_JSON);
     getCollection().insertOne(allTypesDocument);
-
     SparkSession spark = getOrCreateSparkSession();
-    Row actual =
-        spark
-            .read()
-            .format("mongodb")
-            .load()
-            .where("dateTime = cast('2020-01-01T00:00:01.000Z' as timestamp)")
-            .first();
 
+    Dataset<Row> dataset = spark.read().format("mongodb").load();
+
+    // Simple types
+    Row actual = dataset.where("_id = 1").first();
     assertEquals(
         BsonDocument.parse(EXPECTED_BSON_DOCUMENT_JSON),
         new RowToBsonDocumentConverter(actual.schema()).fromRow(actual));
 
-    actual = spark.read().format("mongodb").load().where("arraySimple = array(1, 2, 3)").first();
+    // Casted types
+    actual = dataset.where("dateTime = cast('2020-01-01T00:00:01.000Z' as timestamp)").first();
+    assertEquals(
+        BsonDocument.parse(EXPECTED_BSON_DOCUMENT_JSON),
+        new RowToBsonDocumentConverter(actual.schema()).fromRow(actual));
 
+    // Find complex matches
+    actual = dataset.where("arraySimple = array(1, 2, 3)").first();
+    assertEquals(
+        BsonDocument.parse(EXPECTED_BSON_DOCUMENT_JSON),
+        new RowToBsonDocumentConverter(actual.schema()).fromRow(actual));
+
+    // Find nested matches
+    actual = dataset.where("document.a = 1").first();
+    assertEquals(
+        BsonDocument.parse(EXPECTED_BSON_DOCUMENT_JSON),
+        new RowToBsonDocumentConverter(actual.schema()).fromRow(actual));
+
+    // Functional filters - handled by spark
+    actual = dataset.filter("array_contains(arraySimple, 2)").first();
     assertEquals(
         BsonDocument.parse(EXPECTED_BSON_DOCUMENT_JSON),
         new RowToBsonDocumentConverter(actual.schema()).fromRow(actual));


### PR DESCRIPTION
It now handles error cases better by not throwing an exception. It now
will leave the Filter for Spark to handle.

Now handles nested lookups and pushes them down to the aggregation
framework.

SPARK-359