### PR TITLE
New flag 'upsertDocument' to control the insert behavior of writes

### DIFF
--- a/src/main/scala/com/mongodb/spark/MongoSpark.scala
+++ b/src/main/scala/com/mongodb/spark/MongoSpark.scala
@@ -136,10 +136,10 @@ object MongoSpark {
               val queryDocument = new BsonDocument()
               queryKeyList.foreach(key => queryDocument.append(key, doc.get(key)))
               if (writeConfig.replaceDocument) {
-                new ReplaceOneModel[BsonDocument](queryDocument, doc, new ReplaceOptions().upsert(true))
+                new ReplaceOneModel[BsonDocument](queryDocument, doc, new ReplaceOptions().upsert(writeConfig.upsertDocument))
               } else {
                 queryDocument.keySet().asScala.foreach(doc.remove(_))
-                new UpdateOneModel[BsonDocument](queryDocument, new BsonDocument("$set", doc), new UpdateOptions().upsert(true))
+                new UpdateOneModel[BsonDocument](queryDocument, new BsonDocument("$set", doc), new UpdateOptions().upsert(writeConfig.upsertDocument))
               }
             } else {
               new InsertOneModel[BsonDocument](doc)

--- a/src/main/scala/com/mongodb/spark/config/MongoOutputConfig.scala
+++ b/src/main/scala/com/mongodb/spark/config/MongoOutputConfig.scala
@@ -148,4 +148,13 @@ trait MongoOutputConfig extends MongoCompanionConfig {
    * @since 2.4.1
    */
   val extendedBsonTypesProperty = "extendedBsonTypes".toLowerCase
+
+  /**
+   * The upsert Document property
+   *
+   * If `true`, will use inserts / updates when saving data with an `_id` field. Otherwise, only updates the fields in the Dataset
+   *
+   * Default: None
+   */
+  val upsertDocumentProperty = "upsertDocument".toLowerCase
 }


### PR DESCRIPTION
'upsertDocument' flag passed as spark option control the insert behavior (provided if 'forceInsert' is set to false)

If true - MongoSpark behavior the same as earlier i.e. inserts / updates when saving a Dataset.
If false - MongoSpark does not insert new documents and updates / sets fields for matching documents. 