### PR TITLE
Avoid empty arrays to infer the correct schema (struct array)

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -244,6 +245,18 @@ public final class InferSchema {
                   if ((dataType1 instanceof MapType && dataType2 instanceof StructType)
                       || (dataType1 instanceof StructType && dataType2 instanceof MapType)) {
                     return appendStructToMap(dataType1, dataType2, readConfig);
+                  }
+
+                  if ((dataType1 instanceof StringType && dataType2 instanceof StructType)
+                      || (dataType1 instanceof StructType && dataType2 instanceof StringType)) {
+                    DataType selectedDt;
+                    if (dataType1 instanceof StructType) {
+                      selectedDt = dataType1;
+                    } else {
+                      selectedDt = dataType2;
+                    }
+
+                    return compatibleType(PLACE_HOLDER_DATA_TYPE, selectedDt, readConfig);
                   }
 
                   return DataTypes.StringType; // Lowest common type


### PR DESCRIPTION
Suppose we have a collection containing two documents

```
/* 1 */
{
    "_id" : ObjectId("631565b7f907d46658ee1967"),
    "Result" : {
        "info" : []
    }
}

/* 2 */
{
    "_id" : ObjectId("631565b7f907d46658ee1960"),
    "Result" : {
        "info" : [ 
            {
                "test1" : "2013/99/99 09:36:44",
                "test2" : "test"
            }
        ]
    }
}
```

After inferring the schema, we get
```
array<string>
```
But we expect the following types, just like mongo-spark 3.x as well


```
array<struct<test1:string, test2:string>>
```

I traced the code and found that it may be related to this paragraph

https://github.com/mongodb/mongo-spark/blob/651b139ab1e1fb1a2890e5a827b144214caebaf2/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java#L213

because 2 array contains different element type like `struct<test1:string, test2:string>` and `string`, the string type is selected, because string is Lowest common type,

so I add a new condition to handle string and struct, and always pick up struct type.

Not sure if this modification is appropriate, please review again, Thanks very much!


