### PR TITLE
Support extended json

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -48,7 +48,8 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 
 class MongoBatchTest extends MongoSparkConnectorTestCase {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType());
+      new RowToBsonDocumentConverter(new StructType(), false);
+
   private static final String READ_RESOURCES_HOBBITS_JSON_PATH =
       "src/integrationTest/resources/data/read/hobbits.json";
   private static final String READ_RESOURCES_INFER_SCHEMA_JSON_PATH =

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -191,6 +191,21 @@ public final class ReadConfig extends AbstractMongoConfig {
 
   private static final String STREAM_LOOKUP_FULL_DOCUMENT_DEFAULT = FullDocument.DEFAULT.getValue();
 
+  /**
+   * Output extended JSON for any String types.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value OUTPUT_EXTENDED_JSON_DEFAULT}
+   *
+   * <p>If true, will produce extended JSON for any fields that have the String datatype.
+   *
+   * @since 10.1
+   */
+  public static final String OUTPUT_EXTENDED_JSON_CONFIG = "outputExtendedJson";
+
+  private static final boolean OUTPUT_EXTENDED_JSON_DEFAULT = false;
+
   private final List<BsonDocument> aggregationPipeline;
 
   /**
@@ -276,6 +291,14 @@ public final class ReadConfig extends AbstractMongoConfig {
     } catch (IllegalArgumentException e) {
       throw new ConfigException(e);
     }
+  }
+
+  /**
+   * @return true if should ouput extended JSON
+   * @since 10.1
+   */
+  public boolean outputExtendedJson() {
+    return getBoolean(OUTPUT_EXTENDED_JSON_CONFIG, OUTPUT_EXTENDED_JSON_DEFAULT);
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
@@ -166,6 +166,19 @@ public final class WriteConfig extends AbstractMongoConfig {
 
   private static final boolean UPSERT_DOCUMENT_DEFAULT = true;
 
+  /**
+   * Convert JSON and extended JSON values into their BSON equivalent.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value CONVERT_JSON_DEFAULT}
+   *
+   * @since 10.1
+   */
+  public static final String CONVERT_JSON_CONFIG = "convertJson";
+
+  private static final boolean CONVERT_JSON_DEFAULT = false;
+
   private final WriteConcern writeConcern;
   private final OperationType operationType;
 
@@ -224,6 +237,14 @@ public final class WriteConfig extends AbstractMongoConfig {
   /** @return true if should use an upsert */
   public boolean isUpsert() {
     return getBoolean(UPSERT_DOCUMENT_CONFIG, UPSERT_DOCUMENT_DEFAULT);
+  }
+
+  /**
+   * @return the true if JSON strings should be converted
+   * @since 10.1
+   */
+  public boolean convertJson() {
+    return getBoolean(CONVERT_JSON_CONFIG, CONVERT_JSON_DEFAULT);
   }
 
   private WriteConcern createWriteConcern() {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoBatch.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoBatch.java
@@ -44,7 +44,8 @@ final class MongoBatch implements Batch {
   MongoBatch(final StructType schema, final ReadConfig readConfig) {
     this.schema = schema;
     this.readConfig = readConfig;
-    this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema);
+    this.bsonDocumentToRowConverter =
+        new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
   }
 
   /** Returns a list of partitions that split the collection into parts */

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
@@ -62,7 +62,8 @@ final class MongoContinuousStream implements ContinuousStream {
         () -> "Mongo Continuous streams require a schema to be defined");
     this.schema = schema;
     this.readConfig = readConfig;
-    this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema);
+    this.bsonDocumentToRowConverter =
+        new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
@@ -67,7 +67,8 @@ final class MongoMicroBatchStream implements MicroBatchStream {
         () -> "Mongo micro batch streams require a schema to be defined");
     this.schema = schema;
     this.readConfig = readConfig;
-    this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema);
+    this.bsonDocumentToRowConverter =
+        new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
@@ -73,7 +73,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 public final class MongoScanBuilder
     implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType());
+      new RowToBsonDocumentConverter(new StructType(), false);
   private final StructType schema;
   private final ReadConfig readConfig;
   private final boolean isCaseSensitive;

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/ConverterHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/ConverterHelper.java
@@ -31,7 +31,8 @@ import org.bson.json.JsonWriterSettings;
 
 final class ConverterHelper {
   static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
-  static final JsonWriterSettings DEFAULT_JSON_WRITER_SETTINGS =
+
+  static final JsonWriterSettings RELAXED_JSON_WRITER_SETTINGS =
       JsonWriterSettings.builder()
           .outputMode(JsonMode.RELAXED)
           .binaryConverter(
@@ -46,6 +47,9 @@ final class ConverterHelper {
           .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
           .symbolConverter((value, writer) -> writer.writeString(value))
           .build();
+
+  static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
+      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
   private ConverterHelper() {}
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
@@ -50,6 +50,7 @@ final class MongoDataWriter implements DataWriter<InternalRow> {
   private final int partitionId;
   private final long taskId;
   private final RowToBsonDocumentConverter rowToBsonDocumentConverter;
+
   private final WriteConfig writeConfig;
   private final long epochId;
   private final BulkWriteOptions bulkWriteOptions;
@@ -73,7 +74,8 @@ final class MongoDataWriter implements DataWriter<InternalRow> {
       final long epochId) {
     this.partitionId = partitionId;
     this.taskId = taskId;
-    this.rowToBsonDocumentConverter = new RowToBsonDocumentConverter(schema);
+    this.rowToBsonDocumentConverter =
+        new RowToBsonDocumentConverter(schema, writeConfig.convertJson());
     this.writeConfig = writeConfig;
     this.epochId = epochId;
     this.bulkWriteOptions = new BulkWriteOptions().ordered(writeConfig.isOrdered());

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/BsonDocumentToRowConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/BsonDocumentToRowConverterTest.java
@@ -63,14 +63,21 @@ import com.mongodb.spark.sql.connector.interop.JavaScala;
 public class BsonDocumentToRowConverterTest extends SchemaTest {
 
   private static final BsonDocumentToRowConverter CONVERTER =
-      new BsonDocumentToRowConverter(new StructType());
+      new BsonDocumentToRowConverter(new StructType(), false);
 
   private static final BiFunction<DataType, BsonValue, Object> CONVERT =
       (dataType, bsonValue) -> CONVERTER.convertBsonValue("", dataType, bsonValue);
+
+  private static final BsonDocumentToRowConverter EXTENDED_CONVERTER =
+      new BsonDocumentToRowConverter(new StructType(), true);
+
+  private static final BiFunction<DataType, BsonValue, Object> EXTENDED_CONVERT =
+      (dataType, bsonValue) -> EXTENDED_CONVERTER.convertBsonValue("", dataType, bsonValue);
+
   private static final DataType DECIMAL_TYPE = DataTypes.createDecimalType();
 
   @Test
-  @DisplayName("test string support")
+  @DisplayName("test string support relaxed")
   void testStringSupport() {
     Map<String, String> expected =
         new HashMap<String, String>() {
@@ -94,6 +101,16 @@ public class BsonDocumentToRowConverterTest extends SchemaTest {
 
     BSON_DOCUMENT.forEach(
         (k, v) -> assertEquals(expected.get(k), CONVERT.apply(DataTypes.StringType, v)));
+  }
+
+  @Test
+  @DisplayName("test extended Json string support")
+  void testExtendedJsonStringSupport() {
+    BSON_DOCUMENT_ALL_TYPES.forEach(
+        (k, v) ->
+            assertEquals(
+                ALL_TYPES_EXTENDED_JSON_ROW.get(ALL_TYPES_EXTENDED_JSON_ROW.fieldIndex(k)),
+                EXTENDED_CONVERT.apply(DataTypes.StringType, v)));
   }
 
   @Test
@@ -517,7 +534,7 @@ public class BsonDocumentToRowConverterTest extends SchemaTest {
   @DisplayName("test fromBsonDocument")
   void testFromBsonDocument() {
     BsonDocumentToRowConverter bsonDocumentToRowConverter =
-        new BsonDocumentToRowConverter(ALL_TYPES_ROW.schema());
+        new BsonDocumentToRowConverter(ALL_TYPES_ROW.schema(), false);
     GenericRowWithSchema actual = bsonDocumentToRowConverter.toRow(BSON_DOCUMENT_ALL_TYPES);
 
     assertRows(ALL_TYPES_ROW, actual);
@@ -535,10 +552,9 @@ public class BsonDocumentToRowConverterTest extends SchemaTest {
 
   private void assertRows(final GenericRowWithSchema expected, final GenericRowWithSchema actual) {
     assertEquals(expected.schema(), actual.schema());
-
-    for (int i = 0; i < expected.values().length; i++) {
-      Object expectedValue = expected.values()[i];
-      Object actualValue = actual.values()[i];
+    for (String fieldName : expected.schema().fieldNames()) {
+      Object expectedValue = expected.values()[expected.schema().fieldIndex(fieldName)];
+      Object actualValue = actual.values()[actual.schema().fieldIndex(fieldName)];
       assertRowValues(expectedValue, actualValue);
     }
   }

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/InferSchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/InferSchemaTest.java
@@ -78,7 +78,7 @@ public class InferSchemaTest extends SchemaTest {
   @Test
   void testSingleFullDocument() {
     assertEquals(
-        BSON_DOCUMENT_ALL_TYPES_SCHEMA,
+        BSON_DOCUMENT_ALL_TYPES_SCHEMA_WITH_PLACEHOLDER,
         InferSchema.getDataType(BSON_DOCUMENT_ALL_TYPES, READ_CONFIG));
   }
 
@@ -598,7 +598,7 @@ public class InferSchemaTest extends SchemaTest {
   }
 
   private DataType getDataType(final String fieldName) {
-    return BSON_DOCUMENT_ALL_TYPES_SCHEMA
-        .fields()[BSON_DOCUMENT_ALL_TYPES_SCHEMA.fieldIndex(fieldName)].dataType();
+    return BSON_DOCUMENT_ALL_TYPES_SCHEMA_WITH_PLACEHOLDER
+        .fields()[BSON_DOCUMENT_ALL_TYPES_SCHEMA_WITH_PLACEHOLDER.fieldIndex(fieldName)].dataType();
   }
 }


### PR DESCRIPTION
Added two new configurations:

`spark.mongodb.read.outputExtendedJson=false`
`spark.mongodb.write.convertJson=false`

SPARK-311