### PR TITLE
Ensure null values can be converted to BsonNull

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -108,6 +108,7 @@ class MongoBatchTest extends MongoSparkConnectorTestCase {
           + "\"int64\": {\"$numberLong\": \"52\"}, "
           + "\"maxKey\": \"{\\\"$maxKey\\\": 1}\", "
           + "\"minKey\": \"{\\\"$minKey\\\": 1}\", "
+          + "\"null\": null, "
           + "\"objectId\": \"5f3d1bbde0ca4d2829c91e1d\", "
           + "\"regex\": \"{\\\"$regularExpression\\\": {\\\"pattern\\\": \\\"^test.*regex.*xyz$\\\", \\\"options\\\": \\\"i\\\"}}\", "
           + "\"string\": \"the fox ...\", "

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/write/MongoSparkConnectorWriteTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/write/MongoSparkConnectorWriteTest.java
@@ -41,6 +41,7 @@ import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 import org.bson.BsonDocument;
+import org.bson.BsonNull;
 
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.Projections;
@@ -231,6 +232,7 @@ class MongoSparkConnectorWriteTest extends MongoSparkConnectorTestCase {
             .collectAsList()
             .stream()
             .map(BsonDocument::parse)
+            .peek(d -> d.put("age", d.getOrDefault("age", BsonNull.VALUE)))
             .collect(Collectors.toList());
 
     ArrayList<BsonDocument> actual =

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverter.java
@@ -116,7 +116,9 @@ public final class RowToBsonDocumentConverter implements Serializable {
   @SuppressWarnings("unchecked")
   public BsonValue toBsonValue(final DataType dataType, final Object data) {
     try {
-      if (DataTypes.BinaryType.acceptsType(dataType)) {
+      if (data == null) {
+        return BsonNull.VALUE;
+      } else if (DataTypes.BinaryType.acceptsType(dataType)) {
         return new BsonBinary((byte[]) data);
       } else if (DataTypes.BooleanType.acceptsType(dataType)) {
         return new BsonBoolean((Boolean) data);
@@ -138,7 +140,7 @@ public final class RowToBsonDocumentConverter implements Serializable {
           || DataTypes.TimestampType.acceptsType(dataType)) {
         return new BsonDateTime(((Date) data).getTime());
       } else if (DataTypes.NullType.acceptsType(dataType)) {
-        return new BsonNull();
+        return BsonNull.VALUE;
       } else if (dataType instanceof DecimalType) {
         BigDecimal bigDecimal =
             data instanceof BigDecimal
@@ -180,9 +182,7 @@ public final class RowToBsonDocumentConverter implements Serializable {
         BsonDocument bsonDocument = new BsonDocument();
         for (StructField field : row.schema().fields()) {
           int fieldIndex = row.fieldIndex(field.name());
-          if (!(field.nullable() && row.isNullAt(fieldIndex))) {
-            bsonDocument.append(field.name(), toBsonValue(field.dataType(), row.get(fieldIndex)));
-          }
+          bsonDocument.append(field.name(), toBsonValue(field.dataType(), row.get(fieldIndex)));
         }
         return bsonDocument;
       }

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -70,8 +70,7 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
   @DisplayName("test extended json string types")
   void testExtendedStringTypes() {
     assertEquals(
-        BSON_DOCUMENT_ALL_TYPES_NO_NULL,
-        EXTENDED_JSON_CONVERTER.fromRow(ALL_TYPES_EXTENDED_JSON_ROW));
+        BSON_DOCUMENT_ALL_TYPES, EXTENDED_JSON_CONVERTER.fromRow(ALL_TYPES_EXTENDED_JSON_ROW));
   }
 
   @Test
@@ -142,6 +141,24 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
                     DataTypes.createMapType(DataTypes.StringType, SIMPLE_ROW.schema(), true),
                     true));
 
+    assertEquals(expected, DEFAULT_CONVERTER.fromRow(row));
+  }
+
+  @Test
+  @DisplayName("test null values")
+  void testNullValues() {
+    Row row =
+        new GenericRowWithSchema(
+            new Object[] {null, toSeq("a", null), toScalaMap("k", (String) null)},
+            new StructType()
+                .add("field", DataTypes.StringType)
+                .add("arrayType", DataTypes.createArrayType(DataTypes.StringType, true), true)
+                .add(
+                    "mapType",
+                    DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true),
+                    true));
+    BsonDocument expected =
+        BsonDocument.parse("{field: null, arrayType: ['a', null], mapType: {k: null}}");
     assertEquals(expected, DEFAULT_CONVERTER.fromRow(row));
   }
 

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
@@ -140,14 +140,6 @@ abstract class SchemaTest {
   static final BsonDocument BSON_DOCUMENT_ALL_TYPES =
       RawBsonDocument.parse(BSON_DOCUMENT_ALL_TYPES_JSON);
 
-  // null values aren't copied
-  static final BsonDocument BSON_DOCUMENT_ALL_TYPES_NO_NULL =
-      BsonDocument.parse(BSON_DOCUMENT_ALL_TYPES_JSON);
-
-  static {
-    BSON_DOCUMENT_ALL_TYPES_NO_NULL.remove("null");
-  }
-
   static final StructType BSON_DOCUMENT_ALL_TYPES_SCHEMA =
       new StructType()
           .add("arrayEmpty", DataTypes.createArrayType(DataTypes.StringType, true))


### PR DESCRIPTION
Fixes issue saving arrays / maps containing nulls
Top level fields containing null are included when writing the document. This mirrors nulls and creating of rows.

Users should filter data containing nulls, should they not want to save that data.

SPARK-384
SPARK-351