### PR TITLE
Ensure partitioners can handle lack of count in storagestats

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -471,7 +471,7 @@ class MongoBatchTest extends MongoSparkConnectorTestCase {
 
   @Test
   void testReadFromTimeseriesDatabase() {
-    assumeTrue(isAtLeastFiveDotZero());
+    assumeTrue(isAtLeastFiveDotZero() && !isSharded());
     SparkSession spark = getOrCreateSparkSession();
     getCollection().drop();
 

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
@@ -74,7 +74,7 @@ final class MongoInputPartitionHelper {
           .orElse(mongoInputPartitions)
           .toArray(new MongoInputPartition[0]);
     } catch (RuntimeException ex) {
-      throw new MongoSparkException("Partitioning failed.", ex);
+      throw new MongoSparkException("Partitioning failed. " + ex.getMessage(), ex);
     }
   }
 

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/PaginateBySizePartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/PaginateBySizePartitioner.java
@@ -88,7 +88,7 @@ public final class PaginateBySizePartitioner extends PaginatePartitioner {
     int numDocumentsPerPartition = (int) Math.floor(partitionSizeBytes / avgObjSizeInBytes);
     BsonDocument matchQuery = PartitionerHelper.matchQuery(readConfig.getAggregationPipeline());
     long count;
-    if (matchQuery.isEmpty()) {
+    if (matchQuery.isEmpty() && storageStats.containsKey("count")) {
       count = storageStats.getNumber("count").longValue();
     } else {
       count = readConfig.withCollection(coll -> coll.countDocuments(matchQuery));

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/SamplePartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/SamplePartitioner.java
@@ -108,7 +108,7 @@ public final class SamplePartitioner extends FieldPartitioner {
 
     BsonDocument matchQuery = PartitionerHelper.matchQuery(readConfig.getAggregationPipeline());
     long count;
-    if (matchQuery.isEmpty()) {
+    if (matchQuery.isEmpty() && storageStats.containsKey("count")) {
       count = storageStats.getNumber("count").longValue();
     } else {
       count = readConfig.withCollection(coll -> coll.countDocuments(matchQuery));


### PR DESCRIPTION
Tests against timeseries where there is no count.

SPARK-387