### PR TITLE
Allow to filter out null values from the document saved to the database

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -54,7 +54,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 
 class MongoBatchTest extends MongoSparkConnectorTestCase {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false);
+      new RowToBsonDocumentConverter(new StructType(), false, false);
 
   private static final String READ_RESOURCES_HOBBITS_JSON_PATH =
       "src/integrationTest/resources/data/read/hobbits.json";

--- a/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
@@ -179,6 +179,21 @@ public final class WriteConfig extends AbstractMongoConfig {
 
   private static final boolean CONVERT_JSON_DEFAULT = false;
 
+  /**
+   * Keep null values in the BSON document.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value IGNORE_NONE_DEFAULT}
+   *
+   * <p>If true, will store a field in the database only if it is present.
+   *
+   * @since 10.1
+   */
+  public static final String IGNORE_NONE_CONFIG = "ignoreNone";
+
+  private static final boolean IGNORE_NONE_DEFAULT = false;
+
   private final WriteConcern writeConcern;
   private final OperationType operationType;
 
@@ -245,6 +260,14 @@ public final class WriteConfig extends AbstractMongoConfig {
    */
   public boolean convertJson() {
     return getBoolean(CONVERT_JSON_CONFIG, CONVERT_JSON_DEFAULT);
+  }
+
+  /**
+   * @return the true if null values should not appear in the BSON document
+   * @since 10.1
+   */
+  public boolean ignoreNone() {
+    return getBoolean(IGNORE_NONE_CONFIG, IGNORE_NONE_DEFAULT);
   }
 
   private WriteConcern createWriteConcern() {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
@@ -73,7 +73,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 public final class MongoScanBuilder
     implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false);
+      new RowToBsonDocumentConverter(new StructType(), false, false);
   private final StructType schema;
   private final ReadConfig readConfig;
   private final boolean isCaseSensitive;

--- a/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
@@ -75,7 +75,7 @@ final class MongoDataWriter implements DataWriter<InternalRow> {
     this.partitionId = partitionId;
     this.taskId = taskId;
     this.rowToBsonDocumentConverter =
-        new RowToBsonDocumentConverter(schema, writeConfig.convertJson());
+        new RowToBsonDocumentConverter(schema, writeConfig.convertJson(), writeConfig.ignoreNone());
     this.writeConfig = writeConfig;
     this.epochId = epochId;
     this.bulkWriteOptions = new BulkWriteOptions().ordered(writeConfig.isOrdered());

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -49,9 +49,11 @@ import scala.collection.Seq;
 
 public class RowToBsonDocumentConverterTest extends SchemaTest {
   private static final RowToBsonDocumentConverter DEFAULT_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false);
+      new RowToBsonDocumentConverter(new StructType(), false, false);
   private static final RowToBsonDocumentConverter EXTENDED_JSON_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), true);
+      new RowToBsonDocumentConverter(new StructType(), true, false);
+  private static final RowToBsonDocumentConverter IGNORE_NONE_CONVERTER =
+      new RowToBsonDocumentConverter(new StructType(), false, true);
 
   @Test
   @DisplayName("test simple types")
@@ -160,6 +162,27 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
     BsonDocument expected =
         BsonDocument.parse("{field: null, arrayType: ['a', null], mapType: {k: null}}");
     assertEquals(expected, DEFAULT_CONVERTER.fromRow(row));
+  }
+
+  @Test
+  @DisplayName("test ignore none")
+  void testIgnoreNone() {
+    Row row =
+        new GenericRowWithSchema(
+            new Object[] {null, toSeq("a", null), toScalaMap("k", (String) null)},
+            new StructType()
+                .add("field", DataTypes.StringType)
+                .add("arrayType", DataTypes.createArrayType(DataTypes.StringType, true), true)
+                .add(
+                    "mapType",
+                    DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true),
+                    true));
+    BsonDocument expected = BsonDocument.parse("{arrayType: ['a'], mapType: {}}");
+
+    assertEquals(
+        expected,
+        IGNORE_NONE_CONVERTER.fromRow(row),
+        IGNORE_NONE_CONVERTER.fromRow(row).toString());
   }
 
   @Test


### PR DESCRIPTION
Hello,

One of PRs recently merged to the main branch (#89) changed how the document written to the database looks like.
If previously fields containing null values were excluded, now they are stored in the database. And it is up to the user to filter out the fields containing null values. 

I see some issues with this approach:

1. For large dataframes containing many nullable columns there introduced significant overhead. Now each field has to be in the document written to the database and there will be many empty fields;
2. It is not really convinient to filter out the fields containing null values.

There is MongoDB Scala Driver which provides Macros for conversion of Scala case classes to documents written to the database. And depending on whether you want to keep null values or not it can be achieved with helpers `createCodecProvider` and `createCodecProviderIgnoreNone`. It would be great if this option could also be made available in this library.

To address this issue, I propose adding a new parameter called `ignoreNone` to the write configuration. If it is set to false (default value), the documents saved to the database will contain all the fields present in the dataframe. However, if it is set to true, it will filter out such values during conversion.

Note that for arrays (as well as map structures), any null values inside will also be filtered out.

This PR related to [SPARK-394](https://jira.mongodb.org/projects/SPARK/issues/SPARK-394).