### PR TITLE
Support escaped fieldnames in filters

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
@@ -299,6 +299,7 @@ public final class MongoScanBuilder
   }
 
   private String getFieldName(final String attribute) {
+    // Spark automatically escapes hyphenated names using backticks
     if (attribute.startsWith("`") && attribute.endsWith("`")) {
       return attribute.substring(1, attribute.length() - 1);
     }


### PR DESCRIPTION
Spark automatically escapes some field names
eg ones containing a hyphen. Check and unescape any escaped field names before applying the filter
to MongoDB.

SPARK-393