### PR TITLE
Json string conversion improvements

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -50,12 +50,13 @@ import com.mongodb.client.model.TimeSeriesGranularity;
 import com.mongodb.client.model.TimeSeriesOptions;
 
 import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.config.WriteConfig;
 import com.mongodb.spark.sql.connector.mongodb.MongoSparkConnectorTestCase;
 import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 
 class MongoBatchTest extends MongoSparkConnectorTestCase {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false, false);
+      new RowToBsonDocumentConverter(new StructType(), WriteConfig.ConvertJson.FALSE, false);
 
   private static final String READ_RESOURCES_HOBBITS_JSON_PATH =
       "src/integrationTest/resources/data/read/hobbits.json";

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -55,7 +55,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 
 class MongoBatchTest extends MongoSparkConnectorTestCase {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false);
+      new RowToBsonDocumentConverter(new StructType(), false, false, false);
 
   private static final String READ_RESOURCES_HOBBITS_JSON_PATH =
       "src/integrationTest/resources/data/read/hobbits.json";

--- a/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
@@ -88,16 +88,15 @@ public final class WriteConfig extends AbstractMongoConfig {
     }
 
     static ConvertJson fromString(final String jsonType) {
-      for (ConvertJson convertJsonType : ConvertJson.values()) {
-        if (jsonType.equalsIgnoreCase(TRUE)) {
-          LOGGER.warn("{}: 'true' is deprecated. Use: '{}' instead.", CONVERT_JSON_CONFIG, ANY);
-          return ANY;
-        }
-        if (jsonType.equalsIgnoreCase(convertJsonType.value)) {
-          return convertJsonType;
-        }
+      if (jsonType.equalsIgnoreCase(TRUE)) {
+        LOGGER.warn("{}: '{}' is deprecated. Use: '{}' instead.", CONVERT_JSON_CONFIG, TRUE, ANY);
+        return ANY;
       }
-      throw new ConfigException(format("'%s' is not a valid Convert Json Type", jsonType));
+      try {
+        return ConvertJson.valueOf(jsonType.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException e) {
+        throw new ConfigException(format("'%s' is not a valid Convert Json Type", jsonType), e);
+      }
     }
 
     @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
@@ -22,6 +22,7 @@ import static java.util.Collections.singletonList;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -77,7 +78,7 @@ public final class WriteConfig extends AbstractMongoConfig {
     FALSE("false"),
     /** Try to parse any string as a json value */
     ANY("any"),
-    /** Try to parse any string as a json value */
+    /** Only try to parse strings are potentially json objects or arrays */
     OBJECT_OR_ARRAY_ONLY("objectOrArrayOnly");
 
     private final String value;

--- a/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/WriteConfig.java
@@ -180,6 +180,22 @@ public final class WriteConfig extends AbstractMongoConfig {
   private static final boolean CONVERT_JSON_DEFAULT = false;
 
   /**
+   * Convert only nested JSON objects and arrays into their BSON equivalent.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value CONVERT_JSON_NESTED_VALUES_ONLY_DEFAULT}
+   *
+   * <p>Requires {@value CONVERT_JSON_CONFIG}=true
+   *
+   * @since 10.2
+   */
+  public static final String CONVERT_JSON_NESTED_VALUES_ONLY_CONFIG =
+      "convertJson.nestedValuesOnly";
+
+  private static final boolean CONVERT_JSON_NESTED_VALUES_ONLY_DEFAULT = false;
+
+  /**
    * Ignore null values, even those within arrays or documents.
    *
    * <p>Configuration: {@value}
@@ -260,6 +276,16 @@ public final class WriteConfig extends AbstractMongoConfig {
    */
   public boolean convertJson() {
     return getBoolean(CONVERT_JSON_CONFIG, CONVERT_JSON_DEFAULT);
+  }
+
+  /**
+   * @return the true if only nested JSON strings should be converted
+   * @since 10.2
+   */
+  public boolean convertJsonNestedValuesOnlyConfig() {
+    return convertJson()
+        && getBoolean(
+            CONVERT_JSON_NESTED_VALUES_ONLY_CONFIG, CONVERT_JSON_NESTED_VALUES_ONLY_DEFAULT);
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
@@ -73,7 +73,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 public final class MongoScanBuilder
     implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false);
+      new RowToBsonDocumentConverter(new StructType(), false, false, false);
   private final StructType schema;
   private final ReadConfig readConfig;
   private final boolean isCaseSensitive;

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
@@ -66,6 +66,7 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.spark.sql.connector.assertions.Assertions;
 import com.mongodb.spark.sql.connector.config.MongoConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.config.WriteConfig;
 import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 
 /** A builder for a {@link MongoScan}. */
@@ -73,7 +74,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 public final class MongoScanBuilder
     implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
   private static final RowToBsonDocumentConverter CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false, false);
+      new RowToBsonDocumentConverter(new StructType(), WriteConfig.ConvertJson.FALSE, false);
   private final StructType schema;
   private final ReadConfig readConfig;
   private final boolean isCaseSensitive;

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverter.java
@@ -251,7 +251,7 @@ public final class RowToBsonDocumentConverter implements Serializable {
       case OBJECT_OR_ARRAY_ONLY:
         return isJsonObjectOrArray(data);
       default:
-        throw new IllegalStateException("Unexpected value: " + convertJson);
+        throw new AssertionError("Unexpected value: " + convertJson);
     }
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
@@ -76,10 +76,7 @@ final class MongoDataWriter implements DataWriter<InternalRow> {
     this.taskId = taskId;
     this.rowToBsonDocumentConverter =
         new RowToBsonDocumentConverter(
-            schema,
-            writeConfig.convertJson(),
-            writeConfig.convertJsonNestedValuesOnlyConfig(),
-            writeConfig.ignoreNullValues());
+            schema, writeConfig.convertJson(), writeConfig.ignoreNullValues());
     this.writeConfig = writeConfig;
     this.epochId = epochId;
     this.bulkWriteOptions = new BulkWriteOptions().ordered(writeConfig.isOrdered());

--- a/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/write/MongoDataWriter.java
@@ -76,7 +76,10 @@ final class MongoDataWriter implements DataWriter<InternalRow> {
     this.taskId = taskId;
     this.rowToBsonDocumentConverter =
         new RowToBsonDocumentConverter(
-            schema, writeConfig.convertJson(), writeConfig.ignoreNullValues());
+            schema,
+            writeConfig.convertJson(),
+            writeConfig.convertJsonNestedValuesOnlyConfig(),
+            writeConfig.ignoreNullValues());
     this.writeConfig = writeConfig;
     this.epochId = epochId;
     this.bulkWriteOptions = new BulkWriteOptions().ordered(writeConfig.isOrdered());

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -79,7 +79,8 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
   @DisplayName("test json converter objects or arrays only")
   void testExtendedStringTypes() {
     assertEquals(
-        CONVERT_JSON_NESTED_ONLY_DOCUMENT, NESTED_JSON_CONVERTER.fromRow(CONVERT_JSON_ROW));
+        CONVERT_JSON_OBJECT_OR_ARRAY_ONLY_DOCUMENT,
+        OBJECT_OR_ARRAY_JSON_CONVERTER.fromRow(CONVERT_JSON_ROW));
   }
 
   @Test

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -49,11 +49,15 @@ import scala.collection.Seq;
 
 public class RowToBsonDocumentConverterTest extends SchemaTest {
   private static final RowToBsonDocumentConverter DEFAULT_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false);
-  private static final RowToBsonDocumentConverter EXTENDED_JSON_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), true, false);
+      new RowToBsonDocumentConverter(new StructType(), false, false, false);
+  private static final RowToBsonDocumentConverter JSON_CONVERTER =
+      new RowToBsonDocumentConverter(new StructType(), true, false, false);
+
+  private static final RowToBsonDocumentConverter NESTED_JSON_CONVERTER =
+      new RowToBsonDocumentConverter(new StructType(), true, true, false);
+
   private static final RowToBsonDocumentConverter IGNORE_NULL_VALUES_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, true);
+      new RowToBsonDocumentConverter(new StructType(), false, false, true);
 
   @Test
   @DisplayName("test simple types")
@@ -62,17 +66,18 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
   }
 
   @Test
-  @DisplayName("test relaxed json string types")
-  void testRelaxedStringTypes() {
-    assertEquals(
-        BSON_DOCUMENT_RELAXED, EXTENDED_JSON_CONVERTER.fromRow(ALL_TYPES_RELAXED_JSON_ROW));
+  @DisplayName("test json converter all fields")
+  void testJsonConverter() {
+    assertEquals(BSON_DOCUMENT_RELAXED, JSON_CONVERTER.fromRow(ALL_TYPES_RELAXED_JSON_ROW));
+    assertEquals(BSON_DOCUMENT_ALL_TYPES, JSON_CONVERTER.fromRow(ALL_TYPES_EXTENDED_JSON_ROW));
+    assertEquals(CONVERT_JSON_DOCUMENT, JSON_CONVERTER.fromRow(CONVERT_JSON_ROW));
   }
 
   @Test
-  @DisplayName("test extended json string types")
+  @DisplayName("test json converter nested fields only")
   void testExtendedStringTypes() {
     assertEquals(
-        BSON_DOCUMENT_ALL_TYPES, EXTENDED_JSON_CONVERTER.fromRow(ALL_TYPES_EXTENDED_JSON_ROW));
+        CONVERT_JSON_NESTED_ONLY_DOCUMENT, NESTED_JSON_CONVERTER.fromRow(CONVERT_JSON_ROW));
   }
 
   @Test

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -54,7 +54,7 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
   private static final RowToBsonDocumentConverter JSON_CONVERTER =
       new RowToBsonDocumentConverter(new StructType(), WriteConfig.ConvertJson.ANY, false);
 
-  private static final RowToBsonDocumentConverter NESTED_JSON_CONVERTER =
+  private static final RowToBsonDocumentConverter OBJECT_OR_ARRAY_JSON_CONVERTER =
       new RowToBsonDocumentConverter(
           new StructType(), WriteConfig.ConvertJson.OBJECT_OR_ARRAY_ONLY, false);
 

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -76,7 +76,7 @@ public class RowToBsonDocumentConverterTest extends SchemaTest {
   }
 
   @Test
-  @DisplayName("test json converter nested fields only")
+  @DisplayName("test json converter objects or arrays only")
   void testExtendedStringTypes() {
     assertEquals(
         CONVERT_JSON_NESTED_ONLY_DOCUMENT, NESTED_JSON_CONVERTER.fromRow(CONVERT_JSON_ROW));

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/RowToBsonDocumentConverterTest.java
@@ -42,6 +42,7 @@ import org.bson.BsonDecimal128;
 import org.bson.BsonDocument;
 import org.bson.types.Decimal128;
 
+import com.mongodb.spark.sql.connector.config.WriteConfig;
 import com.mongodb.spark.sql.connector.exceptions.DataException;
 import com.mongodb.spark.sql.connector.interop.JavaScala;
 
@@ -49,15 +50,16 @@ import scala.collection.Seq;
 
 public class RowToBsonDocumentConverterTest extends SchemaTest {
   private static final RowToBsonDocumentConverter DEFAULT_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false, false);
+      new RowToBsonDocumentConverter(new StructType(), WriteConfig.ConvertJson.FALSE, false);
   private static final RowToBsonDocumentConverter JSON_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), true, false, false);
+      new RowToBsonDocumentConverter(new StructType(), WriteConfig.ConvertJson.ANY, false);
 
   private static final RowToBsonDocumentConverter NESTED_JSON_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), true, true, false);
+      new RowToBsonDocumentConverter(
+          new StructType(), WriteConfig.ConvertJson.OBJECT_OR_ARRAY_ONLY, false);
 
   private static final RowToBsonDocumentConverter IGNORE_NULL_VALUES_CONVERTER =
-      new RowToBsonDocumentConverter(new StructType(), false, false, true);
+      new RowToBsonDocumentConverter(new StructType(), WriteConfig.ConvertJson.FALSE, true);
 
   @Test
   @DisplayName("test simple types")

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
@@ -370,7 +370,7 @@ abstract class SchemaTest {
               + " \"array\": [\"012345\", \"true\", {\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"}]"
               + "}");
 
-  static final BsonDocument CONVERT_JSON_NESTED_ONLY_DOCUMENT =
+  static final BsonDocument CONVERT_JSON_OBJECT_OR_ARRAY_ONLY_DOCUMENT =
       BsonDocument.parse(
           "{"
               + " \"booleanString\": \"true\","

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
@@ -343,7 +343,7 @@ abstract class SchemaTest {
           BSON_DOCUMENT_STRING_SCHEMA);
 
   // JSON Conversion types handling
-  static final StructType CONVERT_JSON_SCHEMA =
+  private static final StructType CONVERT_JSON_SCHEMA =
       DataTypes.createStructType(
           asList(
               DataTypes.createStructField("booleanString", DataTypes.StringType, true),

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/SchemaTest.java
@@ -342,6 +342,43 @@ abstract class SchemaTest {
               .toArray(),
           BSON_DOCUMENT_STRING_SCHEMA);
 
+  // JSON Conversion types handling
+  static final StructType CONVERT_JSON_SCHEMA =
+      DataTypes.createStructType(
+          asList(
+              DataTypes.createStructField("booleanString", DataTypes.StringType, true),
+              DataTypes.createStructField("numericString", DataTypes.StringType, true),
+              DataTypes.createStructField("document", DataTypes.StringType, true),
+              DataTypes.createStructField("array", DataTypes.StringType, true)));
+
+  static final GenericRowWithSchema CONVERT_JSON_ROW =
+      new GenericRowWithSchema(
+          asList(
+                  "true",
+                  "012345",
+                  "{\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"}",
+                  "[\"012345\", \"true\", {\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"}]")
+              .toArray(),
+          CONVERT_JSON_SCHEMA);
+
+  static final BsonDocument CONVERT_JSON_DOCUMENT =
+      BsonDocument.parse(
+          "{"
+              + " \"booleanString\": true,"
+              + " \"numericString\": 012345,"
+              + " \"document\": {\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"},"
+              + " \"array\": [\"012345\", \"true\", {\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"}]"
+              + "}");
+
+  static final BsonDocument CONVERT_JSON_NESTED_ONLY_DOCUMENT =
+      BsonDocument.parse(
+          "{"
+              + " \"booleanString\": \"true\","
+              + " \"numericString\": \"012345\","
+              + " \"document\": {\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"},"
+              + " \"array\": [\"012345\", \"true\", {\"a\": \"foo\", \"b\": \"012345\", \"c\": \"true\"}],"
+              + "}");
+
   // Infer Schema
   static final StructType BSON_DOCUMENT_ALL_TYPES_SCHEMA_WITH_PLACEHOLDER =
       DataTypes.createStructType(


### PR DESCRIPTION
Added new config: `convertJson.nestedValuesOnly`
Which will only attempt to convert strings that contain nested Json Objects or Arrays.

Useful when dealing with extended Json and ensures strings that contain json like values are not automatically converted.

Example:

```
convertJson=true
convertJson.nestedValuesOnly=false

"{a: 1}"    => {a: 1}
"[1, 2, 3]" => [1, 2, 3]
"true"      => true
"0122345"   => 12345
"{a:b:c}"   => "{a:b:c}"

convertJson=true
convertJson.nestedValuesOnly=true

"{a: 1}"    => {a: 1}
"[1, 2, 3]" => [1, 2, 3]
"true"      => "true"
"0122345"   => "012345"
"{a:b:c}"   => "{a:b:c}"
```

SPARK-388 SPARK-405