### PR TITLE
Stream based resumability improvements

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
@@ -279,7 +279,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
         mongoConfig,
         withSource("Setup", (msg, coll) -> {} /* NOOP */),
         withSink(
-            "Expecting to see 100 documents",
+            "Expecting to see 125 documents",
             (msg, ds) -> assertEquals(125, ds.countDocuments(), msg)));
   }
 
@@ -289,23 +289,23 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     assumeTrue(isAtLeastFourDotFour());
     testIdentifier = "startAtOperationTime";
 
-    ReadConfig mongoConfig = createMongoConfig().toReadConfig();
+    ReadConfig readConfig = createMongoConfig().toReadConfig();
 
     // Add some documents prior to the start time
-    mongoConfig.doWithCollection(coll -> coll.insertMany(createDocuments(0, 25)));
+    readConfig.doWithCollection(coll -> coll.insertMany(createDocuments(0, 25)));
 
     HELPER.sleep(1000);
     BsonTimestamp currentTimestamp = new BsonTimestamp((int) Instant.now().getEpochSecond(), 0);
 
     // Add some documents post start time
-    mongoConfig.doWithCollection(coll -> coll.insertMany(createDocuments(100, 120)));
+    readConfig.doWithCollection(coll -> coll.insertMany(createDocuments(100, 120)));
     testStreamingQuery(
-        mongoConfig.withOption(
-            ReadConfig.PREFIX + ReadConfig.STREAM_START_AT_OPERATION_TIME_CONFIG,
+        readConfig.withOption(
+            ReadConfig.STREAM_START_AT_OPERATION_TIME_CONFIG,
             String.valueOf(currentTimestamp.getValue())),
         withSource("Setup", (msg, coll) -> {} /* NOOP */),
         withMemorySink(
-            "Expected to see 25 documents",
+            "Expected to see 20 documents",
             (msg, ds) -> assertEquals(20, ds.collectAsList().size(), msg)));
   }
 

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
@@ -301,9 +301,9 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     readConfig.doWithCollection(coll -> coll.insertMany(createDocuments(100, 120)));
     testStreamingQuery(
         readConfig
-            .withOption(ReadConfig.STARTUP_MODE_CONFIG, "timestamp")
+            .withOption(ReadConfig.STREAMING_STARTUP_MODE_CONFIG, "timestamp")
             .withOption(
-                ReadConfig.STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG,
+                ReadConfig.STREAMING_STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG,
                 format("{\"$timestamp\": {\"t\": %d, \"i\": 0}}", currentTimestamp.getTime())),
         withSource("Setup", (msg, coll) -> {} /* NOOP */),
         withMemorySink(

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
@@ -300,9 +300,11 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     // Add some documents post start time
     readConfig.doWithCollection(coll -> coll.insertMany(createDocuments(100, 120)));
     testStreamingQuery(
-        readConfig.withOption(
-            ReadConfig.STREAM_START_AT_OPERATION_TIME_CONFIG,
-            String.valueOf(currentTimestamp.getValue())),
+        readConfig
+            .withOption(ReadConfig.STARTUP_MODE_CONFIG, "timestamp")
+            .withOption(
+                ReadConfig.STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG,
+                format("{\"$timestamp\": {\"t\": %d, \"i\": 0}}", currentTimestamp.getTime())),
         withSource("Setup", (msg, coll) -> {} /* NOOP */),
         withMemorySink(
             "Expected to see 20 documents",

--- a/src/main/java/com/mongodb/spark/sql/connector/config/BsonTimestampParser.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/BsonTimestampParser.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.spark.sql.connector.config;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+import org.bson.BsonTimestamp;
+import org.bson.json.JsonReader;
+
+import com.mongodb.spark.sql.connector.exceptions.ConfigException;
+
+final class BsonTimestampParser {
+  static final String FORMAT_DESCRIPTION =
+      "Must be either an integer number of seconds since the Epoch in the decimal format (example: 30),"
+          + " or an instant in the ISO-8601 format with one second precision (example: '1970-01-01T00:00:30Z'),"
+          + " or a BSON Timestamp in the canonical extended JSON (v2) format"
+          + " (example: '{\"$timestamp\": {\"t\": 30, \"i\": 0}}').";
+
+  static BsonTimestamp parse(
+      final String propertyName, final String propertyValue, @Nullable final Logger logger)
+      throws ConfigException {
+    List<RuntimeException> exceptions = new ArrayList<>();
+    try {
+      return new BsonTimestamp(Integer.parseInt(propertyValue), 0);
+    } catch (RuntimeException e) {
+      exceptions.add(e);
+    }
+    try {
+      Instant instant = Instant.parse(propertyValue);
+      if (logger != null && instant.getNano() > 0) {
+        logger.warn("Trimmed the value {} of `{}` to seconds.", propertyValue, propertyName);
+      }
+      return new BsonTimestamp(Math.toIntExact(instant.getEpochSecond()), 0);
+    } catch (RuntimeException e) {
+      exceptions.add(e);
+    }
+    try (JsonReader jsonReader = new JsonReader(propertyValue)) {
+      return jsonReader.readTimestamp();
+    } catch (RuntimeException e) {
+      exceptions.add(e);
+    }
+    ConfigException configException =
+        new ConfigException(propertyName, propertyValue, FORMAT_DESCRIPTION);
+    exceptions.forEach(configException::addSuppressed);
+    throw configException;
+  }
+
+  private BsonTimestampParser() {}
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -226,8 +226,7 @@ public final class ReadConfig extends AbstractMongoConfig {
    * <p>Specifies how the connector should start up when there is no offset available.
    *
    * <p>Resuming a change stream requires a resume token, which the connector stores as / reads from
-   * the offset. If no offset is available, the connector may either ignore all/some existing source
-   * data, or may at first copy all existing source data and then continue with processing new data.
+   * the offset. If no offset is available, the connector may either ignore all existing data, or may read an offset from the configuration.
    *
    * <p>Possible values are:
    *

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -200,20 +200,12 @@ public final class ReadConfig extends AbstractMongoConfig {
   private static final String STREAM_LOOKUP_FULL_DOCUMENT_DEFAULT = FullDocument.DEFAULT.getValue();
 
   enum StreamingStartupMode {
-    /**
-     * Is equivalent to {@link #LATEST}, and is used to discriminate a situation when the default
-     * behavior is configured explicitly.
-     */
-    DEFAULT_INTERNAL,
-    /** @see #DEFAULT_INTERNAL */
     LATEST,
     TIMESTAMP;
 
     static StreamingStartupMode fromString(final String userStartupMode) {
       try {
-        return userStartupMode.equals(STREAMING_STARTUP_MODE_DEFAULT)
-            ? DEFAULT_INTERNAL
-            : StreamingStartupMode.valueOf(userStartupMode.toUpperCase());
+        return StreamingStartupMode.valueOf(userStartupMode.toUpperCase());
       } catch (IllegalArgumentException e) {
         throw new ConfigException(format("'%s' is not a valid Startup mode", userStartupMode));
       }
@@ -226,7 +218,8 @@ public final class ReadConfig extends AbstractMongoConfig {
    * <p>Specifies how the connector should start up when there is no offset available.
    *
    * <p>Resuming a change stream requires a resume token, which the connector stores as / reads from
-   * the offset. If no offset is available, the connector may either ignore all existing data, or may read an offset from the configuration.
+   * the offset. If no offset is available, the connector may either ignore all existing data, or
+   * may read an offset from the configuration.
    *
    * <p>Possible values are:
    *
@@ -234,19 +227,19 @@ public final class ReadConfig extends AbstractMongoConfig {
    *   <li>'latest' is the default value. The connector creates a new change stream, processes
    *       change events from it and stores resume tokens from them, thus ignoring all existing
    *       source data.
-   *   <li>'timestamp' actuates 'change.stream.startup.mode.timestamp.*' properties." If no such properties are
-   *       configured, then 'timestamp' is equivalent to 'latest'.
+   *   <li>'timestamp' actuates 'change.stream.startup.mode.timestamp.*' properties." If no such
+   *       properties are configured, then 'timestamp' is equivalent to 'latest'.
    * </ul>
    */
   public static final String STREAMING_STARTUP_MODE_CONFIG = "change.stream.startup.mode";
 
-  static final String STREAMING_STARTUP_MODE_DEFAULT = EMPTY_STRING;
+  static final String STREAMING_STARTUP_MODE_DEFAULT = StreamingStartupMode.LATEST.name();
 
   /**
    * The `startAtOperationTime` configuration.
    *
-   * <p>Actuated only if 'change.stream.startup.mode = timestamp'. Specifies the starting point for the change
-   * stream.
+   * <p>Actuated only if 'change.stream.startup.mode = timestamp'. Specifies the starting point for
+   * the change stream.
    *
    * <p>Must be either an integer number of seconds since the Epoch in the decimal format (example:
    * 30), or an instant in the ISO-8601 format with one second precision (example:
@@ -382,7 +375,6 @@ public final class ReadConfig extends AbstractMongoConfig {
         StreamingStartupMode.fromString(
             getOrDefault(STREAMING_STARTUP_MODE_CONFIG, STREAMING_STARTUP_MODE_DEFAULT));
     switch (streamingStartupMode) {
-      case DEFAULT_INTERNAL:
       case LATEST:
         return STREAMING_LATEST_TIMESTAMP;
       case TIMESTAMP:

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -259,7 +259,7 @@ public final class ReadConfig extends AbstractMongoConfig {
    * <p>Note: Requires MongoDB 4.0 or above.
    *
    * <p>See <a
-   * href="https://www.mongodb.com/docs/current/reference/operator/aggregation/changeStream>changeStreams</a>.
+   * href="https://www.mongodb.com/docs/current/reference/operator/aggregation/changeStream">changeStreams</a>.
    */
   public static final String STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG =
       "startup.mode.timestamp.start.at.operation.time";

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -246,7 +246,7 @@ public final class ReadConfig extends AbstractMongoConfig {
   /**
    * The `startAtOperationTime` configuration.
    *
-   * <p>Actuated only if 'startup.mode = timestamp'. Specifies the starting point for the change
+   * <p>Actuated only if 'change.stream.startup.mode = timestamp'. Specifies the starting point for the change
    * stream.
    *
    * <p>Must be either an integer number of seconds since the Epoch in the decimal format (example:

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -235,7 +235,7 @@ public final class ReadConfig extends AbstractMongoConfig {
    *   <li>'latest' is the default value. The connector creates a new change stream, processes
    *       change events from it and stores resume tokens from them, thus ignoring all existing
    *       source data.
-   *   <li>'timestamp' actuates 'startup.mode.timestamp.*' properties." If no such properties are
+   *   <li>'timestamp' actuates 'change.stream.startup.mode.timestamp.*' properties." If no such properties are
    *       configured, then 'timestamp' is equivalent to 'latest'.
    * </ul>
    */

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
 import org.bson.BsonType;
 import org.bson.BsonValue;
 
@@ -192,6 +193,24 @@ public final class ReadConfig extends AbstractMongoConfig {
   private static final String STREAM_LOOKUP_FULL_DOCUMENT_DEFAULT = FullDocument.DEFAULT.getValue();
 
   /**
+   * Streaming start at operation time.
+   *
+   * <p>Specifies the bson timestamp value for the start at operation time.
+   *
+   * <p>See: <a
+   * href="https://www.mongodb.com/docs/v6.0/reference/bson-types/#timestamps">BsonTimestamp</a>.
+   *
+   * <p>Configuration: {@value}
+   *
+   * @since 10.2
+   */
+  public static final String STREAM_START_AT_OPERATION_TIME_CONFIG =
+      "change.stream.start.at.operation.time";
+
+  private static final long STREAM_START_AT_OPERATION_TIME_DEFAULT =
+      new BsonTimestamp(-1, 0).getValue();
+
+  /**
    * Output extended JSON for any String types.
    *
    * <p>Configuration: {@value}
@@ -291,6 +310,18 @@ public final class ReadConfig extends AbstractMongoConfig {
     } catch (IllegalArgumentException e) {
       throw new ConfigException(e);
     }
+  }
+
+  /**
+   * Returns the initial start at operation time for a stream
+   *
+   * <p>Note: This value will be ignored if there is a checkpoint is present for the stream.
+   *
+   * @return the start at operation time for a stream
+   * @since 10.2
+   */
+  public long getStreamStartAtOperationTime() {
+    return getLong(STREAM_START_AT_OPERATION_TIME_CONFIG, STREAM_START_AT_OPERATION_TIME_DEFAULT);
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -27,6 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -44,8 +47,12 @@ import com.mongodb.spark.sql.connector.read.partitioner.Partitioner;
  * <p>The {@link MongoConfig} for reads.
  */
 public final class ReadConfig extends AbstractMongoConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReadConfig.class);
 
   private static final long serialVersionUID = 1L;
+
+  private static final String EMPTY_STRING = "";
+
   /**
    * The partitioner full class name.
    *
@@ -142,7 +149,7 @@ public final class ReadConfig extends AbstractMongoConfig {
    */
   public static final String AGGREGATION_PIPELINE_CONFIG = "aggregation.pipeline";
 
-  public static final String AGGREGATION_PIPELINE_DEFAULT = "";
+  public static final String AGGREGATION_PIPELINE_DEFAULT = EMPTY_STRING;
 
   /**
    * Allow disk use when running the aggregation.
@@ -192,23 +199,73 @@ public final class ReadConfig extends AbstractMongoConfig {
 
   private static final String STREAM_LOOKUP_FULL_DOCUMENT_DEFAULT = FullDocument.DEFAULT.getValue();
 
-  /**
-   * Streaming start at operation time.
-   *
-   * <p>Specifies the bson timestamp value for the start at operation time.
-   *
-   * <p>See: <a
-   * href="https://www.mongodb.com/docs/v6.0/reference/bson-types/#timestamps">BsonTimestamp</a>.
-   *
-   * <p>Configuration: {@value}
-   *
-   * @since 10.2
-   */
-  public static final String STREAM_START_AT_OPERATION_TIME_CONFIG =
-      "change.stream.start.at.operation.time";
+  enum StartupMode {
+    /**
+     * Is equivalent to {@link #LATEST}, and is used to discriminate a situation when the default
+     * behavior is configured explicitly.
+     */
+    DEFAULT_INTERNAL,
+    /** @see #DEFAULT_INTERNAL */
+    LATEST,
+    TIMESTAMP;
 
-  private static final long STREAM_START_AT_OPERATION_TIME_DEFAULT =
-      new BsonTimestamp(-1, 0).getValue();
+    static StartupMode fromString(final String userStartupMode) {
+      try {
+        return userStartupMode.equals(STARTUP_MODE_DEFAULT)
+            ? DEFAULT_INTERNAL
+            : StartupMode.valueOf(userStartupMode.toUpperCase());
+      } catch (IllegalArgumentException e) {
+        throw new ConfigException(format("'%s' is not a valid Startup mode", userStartupMode));
+      }
+    }
+  }
+
+  /**
+   * The start up behavior when there is no stored offset available.
+   *
+   * <p>Specifies how the connector should start up when there is no offset available.
+   *
+   * <p>Resuming a change stream requires a resume token, which the connector stores as / reads from
+   * the offset. If no offset is available, the connector may either ignore all/some existing source
+   * data, or may at first copy all existing source data and then continue with processing new data.
+   *
+   * <p>Possible values are:
+   *
+   * <ul>
+   *   <li>'latest' is the default value. The connector creates a new change stream, processes
+   *       change events from it and stores resume tokens from them, thus ignoring all existing
+   *       source data.
+   *   <li>'timestamp' actuates 'startup.mode.timestamp.*' properties." If no such properties are
+   *       configured, then 'timestamp' is equivalent to 'latest'.
+   * </ul>
+   */
+  public static final String STARTUP_MODE_CONFIG = "startup.mode";
+
+  static final String STARTUP_MODE_DEFAULT = EMPTY_STRING;
+
+  /**
+   * The `startAtOperationTime` configuration.
+   *
+   * <p>Actuated only if 'startup.mode = timestamp'. Specifies the starting point for the change
+   * stream.
+   *
+   * <p>Must be either an integer number of seconds since the Epoch in the decimal format (example:
+   * 30), or an instant in the ISO-8601 format with one second precision (example:
+   * '1970-01-01T00:00:30Z'), or a BSON Timestamp in the canonical extended JSON (v2) format
+   * (example: '{\"$timestamp\": {\"t\": 30, \"i\": 0}}').
+   *
+   * <p>You may specify '0' to start at the beginning of the oplog.
+   *
+   * <p>Note: Requires MongoDB 4.0 or above.
+   *
+   * <p>See <a
+   * href="https://www.mongodb.com/docs/current/reference/operator/aggregation/changeStream>changeStreams</a>.
+   */
+  public static final String STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG =
+      "startup.mode.timestamp.start.at.operation.time";
+
+  static final String STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_DEFAULT = "-1";
+  private static final BsonTimestamp LATEST_TIMESTAMP = new BsonTimestamp(-1, 0);
 
   /**
    * Output extended JSON for any String types.
@@ -315,13 +372,29 @@ public final class ReadConfig extends AbstractMongoConfig {
   /**
    * Returns the initial start at operation time for a stream
    *
-   * <p>Note: This value will be ignored if there is a checkpoint is present for the stream.
+   * <p>Note: This value will be ignored if the timestamp is negative or there is an existing offset
+   * present for the stream.
    *
    * @return the start at operation time for a stream
    * @since 10.2
    */
-  public long getStreamStartAtOperationTime() {
-    return getLong(STREAM_START_AT_OPERATION_TIME_CONFIG, STREAM_START_AT_OPERATION_TIME_DEFAULT);
+  public BsonTimestamp getInitialBsonTimestamp() {
+    StartupMode startupMode =
+        StartupMode.fromString(getOrDefault(STARTUP_MODE_CONFIG, STARTUP_MODE_DEFAULT));
+    switch (startupMode) {
+      case DEFAULT_INTERNAL:
+      case LATEST:
+        return LATEST_TIMESTAMP;
+      case TIMESTAMP:
+        return BsonTimestampParser.parse(
+            STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG,
+            getOrDefault(
+                STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG,
+                STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_DEFAULT),
+            LOGGER);
+      default:
+        throw new AssertionError(format("Unexpected startup mode %s", startupMode));
+    }
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/read/BsonTimestampOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/BsonTimestampOffset.java
@@ -16,6 +16,7 @@
  */
 package com.mongodb.spark.sql.connector.read;
 
+import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 
 import com.mongodb.client.ChangeStreamIterable;
@@ -26,7 +27,8 @@ final class BsonTimestampOffset extends MongoOffset {
   private transient BsonTimestamp bsonTimestamp;
 
   BsonTimestampOffset(final BsonTimestamp value) {
-    this(value.getValue());
+    bsonTimestamp = value;
+    bsonTimestampValue = value.getValue();
   }
 
   BsonTimestampOffset(final long value) {
@@ -34,8 +36,10 @@ final class BsonTimestampOffset extends MongoOffset {
   }
 
   @Override
-  String getOffsetStringValue() {
-    return String.valueOf(bsonTimestampValue);
+  String getOffsetJsonValue() {
+    String docJson =
+        new BsonDocument("v", getBsonTimestamp()).toJson(EXTENDED_JSON_WRITER_SETTINGS);
+    return docJson.substring(6, docJson.length() - 1);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/BsonTimestampOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/BsonTimestampOffset.java
@@ -16,7 +16,8 @@
  */
 package com.mongodb.spark.sql.connector.read;
 
-import org.bson.BsonDocument;
+import static com.mongodb.spark.sql.connector.schema.ConverterHelper.toJson;
+
 import org.bson.BsonTimestamp;
 
 import com.mongodb.client.ChangeStreamIterable;
@@ -31,15 +32,9 @@ final class BsonTimestampOffset extends MongoOffset {
     bsonTimestampValue = value.getValue();
   }
 
-  BsonTimestampOffset(final long value) {
-    this.bsonTimestampValue = value;
-  }
-
   @Override
   String getOffsetJsonValue() {
-    String docJson =
-        new BsonDocument("v", getBsonTimestamp()).toJson(EXTENDED_JSON_WRITER_SETTINGS);
-    return docJson.substring(6, docJson.length() - 1);
+    return toJson(getBsonTimestamp());
   }
 
   @Override
@@ -51,7 +46,7 @@ final class BsonTimestampOffset extends MongoOffset {
     return changeStreamIterable;
   }
 
-  BsonTimestamp getBsonTimestamp() {
+  synchronized BsonTimestamp getBsonTimestamp() {
     if (bsonTimestamp == null) {
       bsonTimestamp = new BsonTimestamp(bsonTimestampValue);
     }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/BsonTimestampOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/BsonTimestampOffset.java
@@ -16,24 +16,27 @@
  */
 package com.mongodb.spark.sql.connector.read;
 
-import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
 
-final class ResumeTokenBasedOffset extends MongoOffset {
+final class BsonTimestampOffset extends MongoOffset {
 
   private static final long serialVersionUID = 1L;
+  private final long value;
 
-  private final BsonDocument resumeToken;
+  BsonTimestampOffset(final BsonTimestamp value) {
+    this(value.getValue());
+  }
 
-  ResumeTokenBasedOffset(final BsonDocument resumeToken) {
-    this.resumeToken = resumeToken;
+  BsonTimestampOffset(final long value) {
+    this.value = value;
   }
 
   @Override
   String getOffsetStringValue() {
-    return resumeToken.toJson();
+    return String.valueOf(value);
   }
 
-  BsonDocument getResumeToken() {
-    return resumeToken;
+  BsonTimestamp getBsonTimestamp() {
+    return new BsonTimestamp(value);
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousInputPartition.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousInputPartition.java
@@ -32,26 +32,26 @@ import org.bson.BsonDocument;
 final class MongoContinuousInputPartition extends MongoInputPartition {
   private static final long serialVersionUID = 1L;
 
-  private final MongoContinuousInputPartitionOffset resumeTokenPartitionOffset;
+  private final MongoContinuousInputPartitionOffset partitionOffset;
 
   /**
    * Construct a new instance
    *
    * @param partitionId the id of the partition
    * @param pipeline the pipeline to partition the collection
-   * @param mongoContinuousInputPartitionOffset the resume token offset for the partition
+   * @param partitionOffset the resume token offset for the partition
    */
   MongoContinuousInputPartition(
       final int partitionId,
       final List<BsonDocument> pipeline,
-      final MongoContinuousInputPartitionOffset mongoContinuousInputPartitionOffset) {
+      final MongoContinuousInputPartitionOffset partitionOffset) {
     super(partitionId, pipeline);
-    this.resumeTokenPartitionOffset = mongoContinuousInputPartitionOffset;
+    this.partitionOffset = partitionOffset;
   }
 
   /** @return the resume token offset */
   MongoContinuousInputPartitionOffset getPartitionOffset() {
-    return resumeTokenPartitionOffset;
+    return partitionOffset;
   }
 
   @Override
@@ -66,12 +66,12 @@ final class MongoContinuousInputPartition extends MongoInputPartition {
       return false;
     }
     final MongoContinuousInputPartition that = (MongoContinuousInputPartition) o;
-    return Objects.equals(resumeTokenPartitionOffset, that.resumeTokenPartitionOffset);
+    return Objects.equals(partitionOffset, that.partitionOffset);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), resumeTokenPartitionOffset);
+    return Objects.hash(super.hashCode(), partitionOffset);
   }
 
   @Override
@@ -85,8 +85,8 @@ final class MongoContinuousInputPartition extends MongoInputPartition {
             .collect(Collectors.joining(",", "[", "]"))
         + ", preferredLocations="
         + Arrays.toString(preferredLocations())
-        + "resumeTokenPartitionOffset="
-        + resumeTokenPartitionOffset
+        + "partitionOffset="
+        + partitionOffset
         + "} ";
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousInputPartitionOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousInputPartitionOffset.java
@@ -21,15 +21,14 @@ import java.util.Objects;
 
 import org.apache.spark.sql.connector.read.streaming.PartitionOffset;
 
-import org.bson.BsonDocument;
-import org.bson.BsonTimestamp;
+import com.mongodb.client.ChangeStreamIterable;
 
 import com.mongodb.spark.sql.connector.assertions.Assertions;
 
 /**
  * The continuous stream partition offset class.
  *
- * <p>Relies on a ResumeTokenOffset for determining the partitions offset.
+ * <p>Relies on a MongoOffset for determining the partitions offset.
  */
 final class MongoContinuousInputPartitionOffset implements PartitionOffset {
   private static final long serialVersionUID = 1L;
@@ -49,25 +48,9 @@ final class MongoContinuousInputPartitionOffset implements PartitionOffset {
     return offset;
   }
 
-  boolean isResumeTokenBasedOffset() {
-    return offset instanceof ResumeTokenBasedOffset;
-  }
-
-  boolean isTimeBasedOffset() {
-    return offset instanceof BsonTimestampOffset;
-  }
-
-  BsonDocument getResumeToken() {
-    Assertions.ensureState(
-        this::isResumeTokenBasedOffset,
-        () -> "The partition offset is not a resume token based offset.");
-    return ((ResumeTokenBasedOffset) offset).getResumeToken();
-  }
-
-  BsonTimestamp getTimestamp() {
-    Assertions.ensureState(
-        this::isTimeBasedOffset, () -> "The partition offset is not a time based offset.");
-    return ((BsonTimestampOffset) offset).getBsonTimestamp();
+  public <T> ChangeStreamIterable<T> applyToChangeStreamIterable(
+      final ChangeStreamIterable<T> changeStreamIterable) {
+    return offset.applyToChangeStreamIterable(changeStreamIterable);
   }
 
   @Override
@@ -89,6 +72,6 @@ final class MongoContinuousInputPartitionOffset implements PartitionOffset {
 
   @Override
   public String toString() {
-    return "MongoContinuousInputPartitionOffset{" + "offset=" + offset.json() + '}';
+    return "MongoContinuousInputPartitionOffset{" + "offset=" + offset + '}';
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousPartitionReader.java
@@ -183,11 +183,7 @@ final class MongoContinuousPartitionReader implements ContinuousPartitionReader<
               .watch(pipeline)
               .fullDocument(readConfig.getStreamFullDocument());
 
-      if (lastOffset.isResumeTokenBasedOffset()) {
-        changeStreamIterable = changeStreamIterable.startAfter(lastOffset.getResumeToken());
-      } else if (lastOffset.isTimeBasedOffset() && lastOffset.getTimestamp().getTime() > 0) {
-        changeStreamIterable = changeStreamIterable.startAtOperationTime(lastOffset.getTimestamp());
-      }
+      changeStreamIterable = lastOffset.applyToChangeStreamIterable(changeStreamIterable);
 
       try {
         changeStreamCursor =

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
@@ -109,7 +109,7 @@ final class MongoContinuousStream implements ContinuousStream {
 
   @Override
   public Offset deserializeOffset(final String json) {
-    return mongoOffsetStore.fromJson(json);
+    return MongoOffset.fromJson(json);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
@@ -18,9 +18,9 @@
 package com.mongodb.spark.sql.connector.read;
 
 import static com.mongodb.spark.sql.connector.read.MongoInputPartitionHelper.generatePipeline;
-import static com.mongodb.spark.sql.connector.read.ResumeTokenBasedOffset.INITIAL_RESUME_TOKEN_OFFSET;
 import static java.lang.String.format;
 
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.streaming.ContinuousPartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.ContinuousStream;
@@ -46,6 +46,7 @@ import com.mongodb.spark.sql.connector.schema.BsonDocumentToRowConverter;
 final class MongoContinuousStream implements ContinuousStream {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoContinuousStream.class);
   private final StructType schema;
+  private final MongoOffsetStore mongoOffsetStore;
   private final ReadConfig readConfig;
   private final BsonDocumentToRowConverter bsonDocumentToRowConverter;
 
@@ -55,12 +56,18 @@ final class MongoContinuousStream implements ContinuousStream {
    * @param schema the schema for the data
    * @param readConfig the read configuration
    */
-  MongoContinuousStream(final StructType schema, final ReadConfig readConfig) {
+  MongoContinuousStream(
+      final StructType schema, final String checkpointLocation, final ReadConfig readConfig) {
     Assertions.validateConfig(
         schema,
         (s) -> !s.isEmpty(),
         () -> "Mongo Continuous streams require a schema to be defined");
     this.schema = schema;
+    this.mongoOffsetStore =
+        new MongoOffsetStore(
+            SparkContext.getOrCreate().hadoopConfiguration(),
+            checkpointLocation,
+            MongoOffset.getInitialOffset(readConfig));
     this.readConfig = readConfig;
     this.bsonDocumentToRowConverter =
         new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
@@ -72,7 +79,7 @@ final class MongoContinuousStream implements ContinuousStream {
       new MongoContinuousInputPartition(
           0,
           generatePipeline(schema, readConfig),
-          new MongoContinuousInputPartitionOffset(((ResumeTokenBasedOffset) start)))
+          new MongoContinuousInputPartitionOffset((MongoOffset) start))
     };
   }
 
@@ -90,25 +97,25 @@ final class MongoContinuousStream implements ContinuousStream {
         () ->
             format(
                 "Unexpected partition offset type. "
-                    + "Expected ResumeTokenPartitionOffset` found `%s`",
+                    + "Expected MongoContinuousInputPartitionOffset` found `%s`",
                 offsets[0].getClass()));
-    return new ResumeTokenBasedOffset(
-        ((MongoContinuousInputPartitionOffset) offsets[0]).getResumeToken());
+    return ((MongoContinuousInputPartitionOffset) offsets[0]).getOffset();
   }
 
   @Override
   public Offset initialOffset() {
-    return INITIAL_RESUME_TOKEN_OFFSET;
+    return mongoOffsetStore.initialOffset();
   }
 
   @Override
   public Offset deserializeOffset(final String json) {
-    return ResumeTokenBasedOffset.parse(json);
+    return mongoOffsetStore.fromJson(json);
   }
 
   @Override
   public void commit(final Offset end) {
     LOGGER.info("ContinuousStream commit: {}", end);
+    mongoOffsetStore.updateOffset((MongoOffset) end);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchInputPartition.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchInputPartition.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.spark.sql.execution.streaming.LongOffset;
-
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 
@@ -35,8 +33,8 @@ import org.bson.BsonTimestamp;
 final class MongoMicroBatchInputPartition extends MongoInputPartition {
   private static final long serialVersionUID = 1L;
 
-  private final LongOffset startOffset;
-  private final LongOffset endOffset;
+  private final BsonTimestampOffset startOffset;
+  private final BsonTimestampOffset endOffset;
 
   /**
    * Construct a new instance
@@ -49,8 +47,8 @@ final class MongoMicroBatchInputPartition extends MongoInputPartition {
   MongoMicroBatchInputPartition(
       final int partitionId,
       final List<BsonDocument> pipeline,
-      final LongOffset startOffset,
-      final LongOffset endOffset) {
+      final BsonTimestampOffset startOffset,
+      final BsonTimestampOffset endOffset) {
     super(partitionId, pipeline);
     this.startOffset = startOffset;
     this.endOffset = endOffset;
@@ -58,12 +56,12 @@ final class MongoMicroBatchInputPartition extends MongoInputPartition {
 
   /** @return the bson timestamp at the start offset */
   public BsonTimestamp getStartOffsetTimestamp() {
-    return new BsonTimestamp((int) startOffset.offset(), 0);
+    return startOffset.getBsonTimestamp();
   }
 
   /** @return the bson timestamp at end offset */
   public BsonTimestamp getEndOffsetTimestamp() {
-    return new BsonTimestamp((int) endOffset.offset(), 0);
+    return endOffset.getBsonTimestamp();
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
@@ -20,14 +20,16 @@ import static com.mongodb.spark.sql.connector.read.MongoInputPartitionHelper.gen
 
 import java.time.Instant;
 
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.connector.read.streaming.Offset;
-import org.apache.spark.sql.execution.streaming.LongOffset;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import org.bson.BsonTimestamp;
 
 import com.mongodb.spark.sql.connector.assertions.Assertions;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
@@ -48,6 +50,7 @@ final class MongoMicroBatchStream implements MicroBatchStream {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoMicroBatchStream.class);
   private final StructType schema;
+  private final MongoOffsetStore mongoOffsetStore;
   private final ReadConfig readConfig;
   private final BsonDocumentToRowConverter bsonDocumentToRowConverter;
   private volatile Long lastTime = Instant.now().getEpochSecond();
@@ -60,12 +63,18 @@ final class MongoMicroBatchStream implements MicroBatchStream {
    * @param schema the schema for the data
    * @param readConfig the read configuration
    */
-  MongoMicroBatchStream(final StructType schema, final ReadConfig readConfig) {
+  MongoMicroBatchStream(
+      final StructType schema, final String checkpointLocation, final ReadConfig readConfig) {
     Assertions.validateConfig(
         schema,
         (s) -> !s.isEmpty(),
         () -> "Mongo micro batch streams require a schema to be defined");
     this.schema = schema;
+    this.mongoOffsetStore =
+        new MongoOffsetStore(
+            SparkContext.getOrCreate().hadoopConfiguration(),
+            checkpointLocation,
+            MongoOffset.getInitialOffset(readConfig));
     this.readConfig = readConfig;
     this.bsonDocumentToRowConverter =
         new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
@@ -77,14 +86,17 @@ final class MongoMicroBatchStream implements MicroBatchStream {
     if (lastTime < now) {
       lastTime = now;
     }
-    return new LongOffset(lastTime);
+    return new BsonTimestampOffset(new BsonTimestamp(lastTime.intValue(), 0));
   }
 
   @Override
   public InputPartition[] planInputPartitions(final Offset start, final Offset end) {
     return new InputPartition[] {
       new MongoMicroBatchInputPartition(
-          partitionId++, generatePipeline(schema, readConfig), (LongOffset) start, (LongOffset) end)
+          partitionId++,
+          generatePipeline(schema, readConfig),
+          (BsonTimestampOffset) start,
+          (BsonTimestampOffset) end)
     };
   }
 
@@ -95,17 +107,18 @@ final class MongoMicroBatchStream implements MicroBatchStream {
 
   @Override
   public Offset initialOffset() {
-    return new LongOffset(-1);
+    return mongoOffsetStore.initialOffset();
   }
 
   @Override
   public Offset deserializeOffset(final String json) {
-    return new LongOffset(Long.parseLong(json));
+    return mongoOffsetStore.fromJson(json);
   }
 
   @Override
   public void commit(final Offset end) {
     LOGGER.info("MicroBatchStream commit: {}", end);
+    mongoOffsetStore.updateOffset((MongoOffset) end);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
@@ -112,7 +112,7 @@ final class MongoMicroBatchStream implements MicroBatchStream {
 
   @Override
   public Offset deserializeOffset(final String json) {
-    return mongoOffsetStore.fromJson(json);
+    return MongoOffset.fromJson(json);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -72,7 +72,7 @@ abstract class MongoOffset extends Offset implements Serializable {
   abstract String getOffsetStringValue();
 
   @Override
-  public String json() {
+  public final String json() {
     return format(JSON_TEMPLATE, getOffsetStringValue());
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.read;
+
+import static java.lang.String.format;
+
+import java.io.Serializable;
+
+import org.apache.spark.sql.connector.read.streaming.Offset;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInvalidOperationException;
+import org.bson.BsonValue;
+import org.bson.json.JsonParseException;
+
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
+
+/** The abstract class for MongoDB change stream based offsets */
+abstract class MongoOffset extends Offset implements Serializable {
+  private static final int VERSION = 1;
+  private static final String JSON_TEMPLATE = format("{\"version\": %s, \"offset\": %%s}", VERSION);
+
+  static BsonTimestampOffset getInitialOffset(final ReadConfig readConfig) {
+    return new BsonTimestampOffset(readConfig.getStreamStartAtOperationTime());
+  }
+
+  static MongoOffset fromJson(final String json) {
+
+    BsonDocument offsetDocument;
+    try {
+      offsetDocument = BsonDocument.parse(json);
+    } catch (JsonParseException | BsonInvalidOperationException e) {
+      throw new MongoSparkException(format("Invalid offset json string: `%s`.", json), e);
+    }
+
+    if (!offsetDocument.containsKey("version")
+        || !offsetDocument.get("version").isNumber()
+        || offsetDocument.get("version").asNumber().intValue() != VERSION) {
+      throw new MongoSparkException(
+          format("Unsupported or missing Version: `%s`. Current Version is: %s", json, VERSION));
+    }
+
+    if (!offsetDocument.containsKey("offset")) {
+      throw new MongoSparkException(format("Missing offset: `%s`.", json));
+    }
+
+    BsonValue offset = offsetDocument.get("offset");
+    if (offset.isNumber()) {
+      return new BsonTimestampOffset(offset.asNumber().longValue());
+    } else if (offset.isDocument()) {
+      return new ResumeTokenBasedOffset(offset.asDocument());
+    }
+    throw new MongoSparkException(
+        format("Invalid offset expected a timestamp or resume token: `%s`. `%s`", offset, json));
+  }
+
+  abstract String getOffsetStringValue();
+
+  @Override
+  public String json() {
+    return format(JSON_TEMPLATE, getOffsetStringValue());
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -27,6 +27,8 @@ import org.bson.BsonInvalidOperationException;
 import org.bson.BsonValue;
 import org.bson.json.JsonParseException;
 
+import com.mongodb.client.ChangeStreamIterable;
+
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 
@@ -70,6 +72,9 @@ abstract class MongoOffset extends Offset implements Serializable {
   }
 
   abstract String getOffsetStringValue();
+
+  abstract <T> ChangeStreamIterable<T> applyToChangeStreamIterable(
+      ChangeStreamIterable<T> changeStreamIterable);
 
   @Override
   public final String json() {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -38,12 +38,7 @@ import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 abstract class MongoOffset extends Offset implements Serializable {
   private static final int VERSION = 1;
   private static final String JSON_TEMPLATE = format("{\"version\": %d, \"offset\": %%s}", VERSION);
-  private static final Set<String> LEGACY_KEYSET =
-      new HashSet<String>() {
-        {
-          add("_data");
-        }
-      };
+  private static final Set<String> LEGACY_KEYSET = Collections.singleton("_data");
 
   static BsonTimestampOffset getInitialOffset(final ReadConfig readConfig) {
     return new BsonTimestampOffset(readConfig.getStreamInitialBsonTimestamp());

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -27,9 +27,7 @@ import org.apache.spark.sql.connector.read.streaming.Offset;
 import org.bson.BsonDocument;
 import org.bson.BsonInvalidOperationException;
 import org.bson.BsonValue;
-import org.bson.json.JsonMode;
 import org.bson.json.JsonParseException;
-import org.bson.json.JsonWriterSettings;
 
 import com.mongodb.client.ChangeStreamIterable;
 
@@ -38,8 +36,6 @@ import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 
 /** The abstract class for MongoDB change stream based offsets */
 abstract class MongoOffset extends Offset implements Serializable {
-  static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
-      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
   private static final int VERSION = 1;
   private static final String JSON_TEMPLATE = format("{\"version\": %d, \"offset\": %%s}", VERSION);
   private static final Set<String> LEGACY_KEYSET =

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -50,7 +50,7 @@ abstract class MongoOffset extends Offset implements Serializable {
       };
 
   static BsonTimestampOffset getInitialOffset(final ReadConfig readConfig) {
-    return new BsonTimestampOffset(readConfig.getInitialBsonTimestamp());
+    return new BsonTimestampOffset(readConfig.getStreamInitialBsonTimestamp());
   }
 
   static MongoOffset fromJson(final String json) {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -52,7 +52,7 @@ abstract class MongoOffset extends Offset implements Serializable {
         || !offsetDocument.get("version").isNumber()
         || offsetDocument.get("version").asNumber().intValue() != VERSION) {
       throw new MongoSparkException(
-          format("Unsupported or missing Version: `%s`. Current Version is: %s", json, VERSION));
+          format("Unsupported or missing Version: `%s`. Current Version is: %d", json, VERSION));
     }
 
     if (!offsetDocument.containsKey("offset")) {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -33,7 +33,7 @@ import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 /** The abstract class for MongoDB change stream based offsets */
 abstract class MongoOffset extends Offset implements Serializable {
   private static final int VERSION = 1;
-  private static final String JSON_TEMPLATE = format("{\"version\": %s, \"offset\": %%s}", VERSION);
+  private static final String JSON_TEMPLATE = format("{\"version\": %d, \"offset\": %%s}", VERSION);
 
   static BsonTimestampOffset getInitialOffset(final ReadConfig readConfig) {
     return new BsonTimestampOffset(readConfig.getStreamStartAtOperationTime());

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffset.java
@@ -19,6 +19,7 @@ package com.mongodb.spark.sql.connector.read;
 import static java.lang.String.format;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffsetStore.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffsetStore.java
@@ -50,12 +50,12 @@ class MongoOffsetStore {
   MongoOffsetStore(final Configuration conf, final String location, final MongoOffset offset) {
     try {
       this.fs = FileSystem.get(URI.create(location), conf);
-      this.path = new Path(URI.create(location));
-      this.offset = offset;
     } catch (IOException e) {
       throw new ConfigException(
           format("Unable to initialize the MongoOffsetStore: %s", location), e);
     }
+    this.path = new Path(URI.create(location));
+    this.offset = offset;
   }
 
   /**
@@ -80,11 +80,7 @@ class MongoOffsetStore {
         throw new ConfigException(format("Failed to parse offset from: %s", path), exception);
       }
     } else {
-      try (FSDataOutputStream out = fs.create(path, true)) {
-        out.write(offset.json().getBytes(StandardCharsets.UTF_8));
-      } catch (IOException exception) {
-        throw new ConfigException(format("Failed to create new offset to: %s", path), exception);
-      }
+      updateOffset(offset);
     }
     LOGGER.info("Initial offset: {}", offset.json());
     return offset;

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffsetStore.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffsetStore.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.mongodb.spark.sql.connector.exceptions.ConfigException;
 
 /** The Mongo offset store for streams. */
-class MongoOffsetStore {
+final class MongoOffsetStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoOffsetStore.class);
   private final Path path;
   private final FileSystem fs;

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffsetStore.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoOffsetStore.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.read;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.spark.sql.connector.exceptions.ConfigException;
+
+/** The Mongo offset store for streams. */
+class MongoOffsetStore {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MongoOffsetStore.class);
+  private final Path path;
+  private final FileSystem fs;
+  private MongoOffset offset;
+
+  /**
+   * Instantiates a new Mongo offset store.
+   *
+   * @param conf the conf
+   * @param location the location
+   * @param offset the offset
+   */
+  MongoOffsetStore(final Configuration conf, final String location, final MongoOffset offset) {
+    try {
+      this.fs = FileSystem.get(URI.create(location), conf);
+      this.path = new Path(URI.create(location));
+      this.offset = offset;
+    } catch (IOException e) {
+      throw new ConfigException(
+          format("Unable to initialize the MongoOffsetStore: %s", location), e);
+    }
+  }
+
+  /**
+   * Initial offset Mongo offset.
+   *
+   * @return the Mongo offset
+   */
+  public MongoOffset initialOffset() {
+    boolean exists;
+    try {
+      exists = fs.exists(path);
+    } catch (IOException e) {
+      throw new ConfigException(
+          format("Unable to determine if the checkpoint location exists: %s", path), e);
+    }
+
+    if (exists) {
+      try (FSDataInputStream in = fs.open(path)) {
+        byte[] buf = IOUtils.toByteArray(in);
+        offset = fromJson(new String(buf, StandardCharsets.UTF_8));
+      } catch (IOException exception) {
+        throw new ConfigException(format("Failed to parse offset from: %s", path), exception);
+      }
+    } else {
+      try (FSDataOutputStream out = fs.create(path, true)) {
+        out.write(offset.json().getBytes(StandardCharsets.UTF_8));
+      } catch (IOException exception) {
+        throw new ConfigException(format("Failed to create new offset to: %s", path), exception);
+      }
+    }
+    LOGGER.info("Initial offset: {}", offset.json());
+    return offset;
+  }
+
+  /**
+   * Update offset.
+   *
+   * @param offset the offset
+   */
+  public void updateOffset(final MongoOffset offset) {
+    try (FSDataOutputStream out = fs.create(path, true)) {
+      out.write(offset.json().getBytes(StandardCharsets.UTF_8));
+    } catch (IOException exception) {
+      throw new ConfigException(
+          format("Failed to update new offset to: %s at %s", offset.json(), path), exception);
+    }
+  }
+
+  MongoOffset fromJson(final String json) {
+    return MongoOffset.fromJson(json);
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScan.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScan.java
@@ -70,10 +70,6 @@ final class MongoScan implements Scan {
    *
    * <p>Note: Requires MongoDB 4.2+ To support continuing a change stream after a collection has
    * been dropped.
-   *
-   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
-   *     recovery. Data streams for the same logical source in the same query will be given the same
-   *     checkpointLocation.
    */
   @Override
   public MicroBatchStream toMicroBatchStream(final String checkpointLocation) {
@@ -88,10 +84,6 @@ final class MongoScan implements Scan {
    *
    * <p>Note: Requires MongoDB 4.2+ To support continuing a change stream after a collection has
    * been dropped.
-   *
-   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
-   *     recovery. Data streams for the same logical source in the same query will be given the same
-   *     checkpointLocation.
    */
   @Override
   public ContinuousStream toContinuousStream(final String checkpointLocation) {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScan.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScan.java
@@ -71,11 +71,13 @@ final class MongoScan implements Scan {
    * <p>Note: Requires MongoDB 4.2+ To support continuing a change stream after a collection has
    * been dropped.
    *
-   * @param checkpointLocation check point locations are not supported
+   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
+   *     recovery. Data streams for the same logical source in the same query will be given the same
+   *     checkpointLocation.
    */
   @Override
   public MicroBatchStream toMicroBatchStream(final String checkpointLocation) {
-    return new MongoMicroBatchStream(schema, readConfig);
+    return new MongoMicroBatchStream(schema, checkpointLocation, readConfig);
   }
 
   /**
@@ -87,10 +89,12 @@ final class MongoScan implements Scan {
    * <p>Note: Requires MongoDB 4.2+ To support continuing a change stream after a collection has
    * been dropped.
    *
-   * @param checkpointLocation check point locations are not supported
+   * @param checkpointLocation a path to Hadoop FS scratch space that can be used for failure
+   *     recovery. Data streams for the same logical source in the same query will be given the same
+   *     checkpointLocation.
    */
   @Override
   public ContinuousStream toContinuousStream(final String checkpointLocation) {
-    return new MongoContinuousStream(schema, readConfig);
+    return new MongoContinuousStream(schema, checkpointLocation, readConfig);
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenBasedOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenBasedOffset.java
@@ -16,6 +16,8 @@
  */
 package com.mongodb.spark.sql.connector.read;
 
+import static com.mongodb.spark.sql.connector.schema.ConverterHelper.toJson;
+
 import org.bson.BsonDocument;
 
 import com.mongodb.client.ChangeStreamIterable;
@@ -32,7 +34,7 @@ final class ResumeTokenBasedOffset extends MongoOffset {
 
   @Override
   String getOffsetJsonValue() {
-    return resumeToken.toJson(EXTENDED_JSON_WRITER_SETTINGS);
+    return toJson(resumeToken);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenBasedOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenBasedOffset.java
@@ -31,17 +31,13 @@ final class ResumeTokenBasedOffset extends MongoOffset {
   }
 
   @Override
-  String getOffsetStringValue() {
-    return resumeToken.toJson();
+  String getOffsetJsonValue() {
+    return resumeToken.toJson(EXTENDED_JSON_WRITER_SETTINGS);
   }
 
   @Override
   <T> ChangeStreamIterable<T> applyToChangeStreamIterable(
       final ChangeStreamIterable<T> changeStreamIterable) {
     return changeStreamIterable.startAfter(resumeToken);
-  }
-
-  BsonDocument getResumeToken() {
-    return resumeToken;
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenBasedOffset.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenBasedOffset.java
@@ -18,6 +18,8 @@ package com.mongodb.spark.sql.connector.read;
 
 import org.bson.BsonDocument;
 
+import com.mongodb.client.ChangeStreamIterable;
+
 final class ResumeTokenBasedOffset extends MongoOffset {
 
   private static final long serialVersionUID = 1L;
@@ -31,6 +33,12 @@ final class ResumeTokenBasedOffset extends MongoOffset {
   @Override
   String getOffsetStringValue() {
     return resumeToken.toJson();
+  }
+
+  @Override
+  <T> ChangeStreamIterable<T> applyToChangeStreamIterable(
+      final ChangeStreamIterable<T> changeStreamIterable) {
+    return changeStreamIterable.startAfter(resumeToken);
   }
 
   BsonDocument getResumeToken() {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenTimestampHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/ResumeTokenTimestampHelper.java
@@ -28,7 +28,12 @@ import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 final class ResumeTokenTimestampHelper {
 
   /**
-   * The resume token has the following structure:
+   * Returns the BsonTimestamp from a resume token.
+   *
+   * <p>Handles server based resume tokens or approximated Bson documents with a `_data` field that
+   * contains a BsonTimestamp.
+   *
+   * <p>Server based resume tokens have the following structure:
    *
    * <p>1. It's a document containing a single field named "_data" whose value is a string
    *
@@ -53,6 +58,10 @@ final class ResumeTokenTimestampHelper {
     }
 
     BsonValue data = resumeToken.get("_data");
+    if (data.isTimestamp()) {
+      return data.asTimestamp();
+    }
+
     if (!data.isString()) {
       throw new MongoSparkException(
           "Invalid resume token, expected string value for `_data` field, but found: "

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/BsonDocumentToRowConverter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/BsonDocumentToRowConverter.java
@@ -18,6 +18,7 @@
 package com.mongodb.spark.sql.connector.schema;
 
 import static com.mongodb.spark.sql.connector.schema.ConverterHelper.BSON_VALUE_CODEC;
+import static com.mongodb.spark.sql.connector.schema.ConverterHelper.toJson;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -307,22 +308,7 @@ public final class BsonDocumentToRowConverter implements Serializable {
   }
 
   private String convertToString(final BsonValue bsonValue) {
-    switch (bsonValue.getBsonType()) {
-      case STRING:
-        return bsonValue.asString().getValue();
-      case DOCUMENT:
-        return bsonValue.asDocument().toJson(getJsonWriterSettings());
-      default:
-        String value = new BsonDocument("v", bsonValue).toJson(getJsonWriterSettings());
-        // Strip down to just the value
-        value = value.substring(6, value.length() - 1);
-        // Remove unnecessary quotes of BsonValues converted to Strings.
-        // Such as BsonBinary base64 string representations
-        if (value.startsWith("\"") && value.endsWith("\"")) {
-          value = value.substring(1, value.length() - 1);
-        }
-        return value;
-    }
+    return toJson(bsonValue, getJsonWriterSettings());
   }
 
   private BsonNumber convertToBsonNumber(

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/ConverterHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/ConverterHelper.java
@@ -23,13 +23,15 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
+import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.codecs.BsonValueCodec;
 import org.bson.codecs.Codec;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
 
-final class ConverterHelper {
+/** Shared converter helper methods and statics */
+public final class ConverterHelper {
   static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
 
   static final JsonWriterSettings RELAXED_JSON_WRITER_SETTINGS =
@@ -50,6 +52,35 @@ final class ConverterHelper {
 
   static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
       JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
+
+  /**
+   * Converts a bson value into its extended JSON form
+   *
+   * @param bsonValue the bson value
+   * @return the extended JSON form
+   */
+  public static String toJson(final BsonValue bsonValue) {
+    return toJson(bsonValue, EXTENDED_JSON_WRITER_SETTINGS);
+  }
+
+  static String toJson(final BsonValue bsonValue, final JsonWriterSettings jsonWriterSettings) {
+    switch (bsonValue.getBsonType()) {
+      case STRING:
+        return bsonValue.asString().getValue();
+      case DOCUMENT:
+        return bsonValue.asDocument().toJson(jsonWriterSettings);
+      default:
+        String value = new BsonDocument("v", bsonValue).toJson(jsonWriterSettings);
+        // Strip down to just the value
+        value = value.substring(6, value.length() - 1);
+        // Remove unnecessary quotes of BsonValues converted to Strings.
+        // Such as BsonBinary base64 string representations
+        if (value.startsWith("\"") && value.endsWith("\"")) {
+          value = value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+  }
 
   private ConverterHelper() {}
 }

--- a/src/test/java/com/mongodb/spark/sql/connector/config/BsonTimestampParserTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/config/BsonTimestampParserTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.config;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import org.bson.BsonTimestamp;
+
+import com.mongodb.spark.sql.connector.exceptions.ConfigException;
+
+final class BsonTimestampParserTest {
+  @Test
+  void parse() {
+    BsonTimestamp expected = new BsonTimestamp(30, 0);
+    assertAll(
+        () -> assertEquals(expected, parse("30")),
+        () -> assertEquals(expected, parse("1970-01-01T00:00:30Z")),
+        () -> assertEquals(expected, parse("{\"$timestamp\": {\"t\": 30, \"i\": 0}}")),
+        () -> assertThrows(ConfigException.class, () -> parse("123.456")));
+  }
+
+  private static BsonTimestamp parse(final String v) throws ConfigException {
+    return BsonTimestampParser.parse("", v, null);
+  }
+}

--- a/src/test/java/com/mongodb/spark/sql/connector/read/MongoOffsetTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/read/MongoOffsetTest.java
@@ -40,7 +40,7 @@ public class MongoOffsetTest {
       "{\"version\": 1, \"offset\": {\"_data\": \"123\"}}";
 
   private static final MongoOffset DEFAULT_TIMESTAMP_OFFSET =
-      new BsonTimestampOffset(new BsonTimestamp(-1, 0));
+      new BsonTimestampOffset(new BsonTimestamp(-1));
 
   private static final MongoOffset TIMESTAMP_OFFSET =
       new BsonTimestampOffset(new BsonTimestamp(5000, 0));
@@ -56,9 +56,10 @@ public class MongoOffsetTest {
         TIMESTAMP_OFFSET,
         MongoOffset.getInitialOffset(
             readConfig
-                .withOption(ReadConfig.STARTUP_MODE_CONFIG, "timestamp")
+                .withOption(ReadConfig.STREAMING_STARTUP_MODE_CONFIG, "timestamp")
                 .withOption(
-                    ReadConfig.STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG, "5000")));
+                    ReadConfig.STREAMING_STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG,
+                    "5000")));
     assertEquals(MongoOffset.fromJson(RESUME_TOKEN_OFFSET_JSON), RESUME_TOKEN_OFFSET);
   }
 

--- a/src/test/java/com/mongodb/spark/sql/connector/read/MongoOffsetTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/read/MongoOffsetTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.read;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+
+import com.mongodb.spark.sql.connector.config.MongoConfig;
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
+
+public class MongoOffsetTest {
+
+  private static final String TIMESTAMP_OFFSET_JSON = "{\"version\": 1, \"offset\": 5000}";
+  private static final String RESUME_TOKEN_OFFSET_JSON =
+      "{\"version\": 1, \"offset\": {\"_data\": \"123\"}}";
+
+  private static final MongoOffset DEFAULT_TIMESTAMP_OFFSET =
+      new BsonTimestampOffset(new BsonTimestamp(-1, 0));
+
+  private static final MongoOffset TIMESTAMP_OFFSET = new BsonTimestampOffset(5000);
+  private static final MongoOffset RESUME_TOKEN_OFFSET =
+      new ResumeTokenBasedOffset(new BsonDocument("_data", new BsonString("123")));
+
+  @Test
+  public void testGetInitialConfig() {
+    ReadConfig readConfig = MongoConfig.createConfig(new HashMap<>()).toReadConfig();
+
+    assertEquals(DEFAULT_TIMESTAMP_OFFSET, MongoOffset.getInitialOffset(readConfig));
+    assertEquals(
+        TIMESTAMP_OFFSET,
+        MongoOffset.getInitialOffset(
+            readConfig.withOption(ReadConfig.STREAM_START_AT_OPERATION_TIME_CONFIG, "5000")));
+    assertEquals(MongoOffset.fromJson(RESUME_TOKEN_OFFSET_JSON), RESUME_TOKEN_OFFSET);
+  }
+
+  @Test
+  public void testProducesTheExpectedOffsets() {
+    assertEquals(MongoOffset.fromJson(TIMESTAMP_OFFSET_JSON), TIMESTAMP_OFFSET);
+    assertEquals(MongoOffset.fromJson(RESUME_TOKEN_OFFSET_JSON), RESUME_TOKEN_OFFSET);
+
+    assertEquals(TIMESTAMP_OFFSET_JSON, TIMESTAMP_OFFSET.json());
+    assertEquals(RESUME_TOKEN_OFFSET_JSON, RESUME_TOKEN_OFFSET.json());
+  }
+
+  @Test
+  public void testValidation() {
+    MongoSparkException error =
+        assertThrows(MongoSparkException.class, () -> MongoOffset.fromJson("\"version\": 1"));
+    assertTrue(error.getMessage().startsWith("Invalid offset json string"));
+
+    error =
+        assertThrows(
+            MongoSparkException.class,
+            () -> MongoOffset.fromJson("{\"version\": \"1\", \"offset\": -1}"));
+    assertTrue(error.getMessage().startsWith("Unsupported or missing Version"));
+
+    error =
+        assertThrows(
+            MongoSparkException.class,
+            () -> MongoOffset.fromJson("{\"version\": 2, \"offset\": -1}"));
+    assertTrue(error.getMessage().startsWith("Unsupported or missing Version"));
+
+    error = assertThrows(MongoSparkException.class, () -> MongoOffset.fromJson("{\"version\": 1}"));
+    assertTrue(error.getMessage().startsWith("Missing offset"));
+
+    error =
+        assertThrows(
+            MongoSparkException.class,
+            () -> MongoOffset.fromJson("{\"version\": 1, \"offset\": \"123\"}"));
+    assertTrue(
+        error.getMessage().startsWith("Invalid offset expected a timestamp or resume token:"));
+  }
+}

--- a/src/test/java/com/mongodb/spark/sql/connector/read/MongoOffsetTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/read/MongoOffsetTest.java
@@ -34,14 +34,16 @@ import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 
 public class MongoOffsetTest {
 
-  private static final String TIMESTAMP_OFFSET_JSON = "{\"version\": 1, \"offset\": 5000}";
+  private static final String TIMESTAMP_OFFSET_JSON =
+      "{\"version\": 1, \"offset\": {\"$timestamp\": {\"t\": 5000, \"i\": 0}}}";
   private static final String RESUME_TOKEN_OFFSET_JSON =
       "{\"version\": 1, \"offset\": {\"_data\": \"123\"}}";
 
   private static final MongoOffset DEFAULT_TIMESTAMP_OFFSET =
       new BsonTimestampOffset(new BsonTimestamp(-1, 0));
 
-  private static final MongoOffset TIMESTAMP_OFFSET = new BsonTimestampOffset(5000);
+  private static final MongoOffset TIMESTAMP_OFFSET =
+      new BsonTimestampOffset(new BsonTimestamp(5000, 0));
   private static final MongoOffset RESUME_TOKEN_OFFSET =
       new ResumeTokenBasedOffset(new BsonDocument("_data", new BsonString("123")));
 
@@ -53,7 +55,10 @@ public class MongoOffsetTest {
     assertEquals(
         TIMESTAMP_OFFSET,
         MongoOffset.getInitialOffset(
-            readConfig.withOption(ReadConfig.STREAM_START_AT_OPERATION_TIME_CONFIG, "5000")));
+            readConfig
+                .withOption(ReadConfig.STARTUP_MODE_CONFIG, "timestamp")
+                .withOption(
+                    ReadConfig.STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG, "5000")));
     assertEquals(MongoOffset.fromJson(RESUME_TOKEN_OFFSET_JSON), RESUME_TOKEN_OFFSET);
   }
 


### PR DESCRIPTION
* Added `change.stream.start.at.operation.time` to allow configurable start time for microbatch or continuous streams.
* Added `MongoOffsetStore` for automatic storing and retrieving MongoOffsets. Allowing resumability of streams. Uses the `checkpointLocation` stream configuration.

SPARK-378 SPARK-379