### PR TITLE
Use $ne for isNotNull

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -387,7 +387,8 @@ class MongoBatchTest extends MongoSparkConnectorTestCase {
             .map((MapFunction<Row, String>) r -> r.getString(2), Encoders.STRING())
             .collectAsList());
 
-    // IsNotNull - filter handled by Spark alone
+    // IsNotNull
+    getCollection().insertOne(BsonDocument.parse("{_id: 11, name: 'Gollum', age: null}"));
     assertIterableEquals(
         asList(
             "Bilbo Baggins",

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScanBuilder.java
@@ -236,7 +236,7 @@ public final class MongoScanBuilder
     } else if (filter instanceof IsNotNull) {
       IsNotNull isNotNullFilter = (IsNotNull) filter;
       String fieldName = getFieldName(isNotNullFilter.attribute());
-      return new FilterAndPipelineStage(filter, Filters.exists(fieldName, true));
+      return new FilterAndPipelineStage(filter, Filters.ne(fieldName, null));
     } else if (filter instanceof LessThan) {
       LessThan lessThan = (LessThan) filter;
       String fieldName = getFieldName(lessThan.attribute());


### PR DESCRIPTION
~[$ne](https://www.mongodb.com/docs/manual/reference/operator/query/ne/#mongodb-query-op.-ne) also excludes documents where the field doesn't exist (this used to not be the case).~

SPARK-410