### PR TITLE
Stop calling `MongoMicroBatchPartitionReader.tryNext` if the resume token timestamp is equal to the end offset timestamp

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
@@ -109,7 +109,7 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
         && cursor.getServerCursor() != null
         && (cursor.getResumeToken() == null
             || getTimestamp(cursor.getResumeToken()).compareTo(partition.getEndOffsetTimestamp())
-                <= 0));
+                < 0));
 
     boolean hasNext = cursorNext != null;
     if (hasNext) {


### PR DESCRIPTION
SPARK-416