### PR TITLE
Support scanning from multiple collections

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
@@ -732,7 +732,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
       final BiConsumer<String, MongoCollection<BsonDocument>> biConsumer) {
     return mongoConfig -> {
       if (msg != null) {
-        LOGGER.info("-> With source: " + msg);
+        LOGGER.info("-> With source: {}", msg);
       }
       ReadConfig readConfig = mongoConfig.toReadConfig();
       MongoCollection<BsonDocument> collection = readConfig.withClient(client -> client
@@ -746,7 +746,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
       @Nullable final String msg, final BiConsumer<String, MongoDatabase> biConsumer) {
     return mongoConfig -> {
       if (msg != null) {
-        LOGGER.info("-> With source: " + msg);
+        LOGGER.info("-> With source: {}", msg);
       }
       ReadConfig readConfig = mongoConfig.toReadConfig();
       MongoDatabase db =

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
@@ -19,9 +19,11 @@ package com.mongodb.spark.sql.connector.read;
 import static com.mongodb.spark.sql.connector.config.MongoConfig.COMMENT_CONFIG;
 import static com.mongodb.spark.sql.connector.config.MongoConfig.PREFIX;
 import static java.lang.String.format;
+import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.joining;
 import static org.apache.spark.sql.types.DataTypes.createStructField;
 import static org.apache.spark.sql.types.DataTypes.createStructType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,9 +34,12 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.Updates;
+import com.mongodb.lang.Nullable;
+import com.mongodb.spark.sql.connector.config.CollectionsConfig;
 import com.mongodb.spark.sql.connector.config.MongoConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.config.WriteConfig;
@@ -46,12 +51,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -66,6 +73,8 @@ import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonTimestamp;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.opentest4j.AssertionFailedError;
 
 /**
@@ -76,7 +85,6 @@ import org.opentest4j.AssertionFailedError;
  * return immediately perhaps waiting for the stream to complete.
  */
 abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
-
   /*
    *
    */
@@ -93,12 +101,15 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
 
   private String testIdentifier;
 
-  @Test
-  void testStream() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStream(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
-    testIdentifier = "Simple";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("Simple", collectionsConfigType);
     testStreamingQuery(
-        createMongoConfig(),
+        createMongoConfig(collectionsConfigType),
         withSource("inserting 0-25", (msg, coll) -> coll.insertMany(createDocuments(0, 25))),
         withMemorySink(
             "Expected to see 25 documents",
@@ -109,14 +120,75 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(50, ds.collectAsList().size(), msg)));
   }
 
-  @Test
-  void testStreamHandlesCollectionDrop() {
+  @ParameterizedTest
+  @ValueSource(strings = {"MULTIPLE", "ALL"})
+  void testStreamFromActuallyMultipleCollections(final String collectionsConfigModeStr) {
+    assumeTrue(supportsChangeStreams());
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("ActuallyMultiple", collectionsConfigType);
+    String collectionName1 = collectionName() + "_1";
+    String collectionName2 = collectionName() + "_2";
+    String collectionName3 = collectionName() + "_3";
+    int expectedNumberOfDocuments;
+    Set<String> expectedCollectionNames;
+    String collectionNameOptionValue;
+    if (collectionsConfigType == CollectionsConfig.Type.ALL) {
+      expectedNumberOfDocuments = 3;
+      expectedCollectionNames =
+          Stream.of(collectionName1, collectionName2, collectionName3).collect(Collectors.toSet());
+      collectionNameOptionValue = "*";
+    } else {
+      expectedNumberOfDocuments = 2;
+      expectedCollectionNames =
+          Stream.of(collectionName1, collectionName3).collect(Collectors.toSet());
+      collectionNameOptionValue = join(",", expectedCollectionNames);
+    }
+    testStreamingQuery(
+        createMongoConfig(collectionsConfigType)
+            .withOption(
+                ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG,
+                collectionNameOptionValue),
+        DEFAULT_SCHEMA.add(
+            "ns", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType)),
+        withSourceDb("Inserting 0-1 in " + collectionName1, (msg, db) -> db.getCollection(
+                collectionName1, BsonDocument.class)
+            .insertMany(createDocuments(0, 1))),
+        withSourceDb("Inserting 2-3 in " + collectionName2, (msg, db) -> db.getCollection(
+                collectionName2, BsonDocument.class)
+            .insertMany(createDocuments(2, 3))),
+        withSourceDb("Inserting 3-4 in " + collectionName3, (msg, db) -> db.getCollection(
+                collectionName3, BsonDocument.class)
+            .insertMany(createDocuments(3, 4))),
+        withMemorySink(
+            format(
+                "Expected to see %d documents from %s",
+                expectedNumberOfDocuments, expectedCollectionNames),
+            (msg, ds) -> {
+              List<Row> rows = ds.collectAsList();
+              assertEquals(expectedNumberOfDocuments, rows.size(), msg);
+              Set<String> actualCollectionNames = rows.stream()
+                  .map(row -> row.<String, String>getMap(row.fieldIndex("ns"))
+                      .get("coll")
+                      .get())
+                  .collect(Collectors.toSet());
+              assertEquals(expectedCollectionNames, actualCollectionNames, msg);
+            }));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamHandlesCollectionDrop(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
 
-    testIdentifier = "WithDrop";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("WithDrop", collectionsConfigType);
+    int expectedInvalidateDocumentsCount =
+        collectionsConfigType == CollectionsConfig.Type.SINGLE ? 1 : 0;
     testStreamingQuery(
-        createMongoConfig(),
+        createMongoConfig(collectionsConfigType),
         withSource("inserting 0-25", (msg, coll) -> coll.insertMany(createDocuments(0, 25))),
         withMemorySink(
             "Expected to see 25 documents",
@@ -131,24 +203,27 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
                     .count(),
                 msg)),
         withMemorySink(
-            "Expected to see 1 invalidate document",
+            "Expected to see " + expectedInvalidateDocumentsCount + " invalidate document",
             (msg, ds) -> assertEquals(
-                1,
+                expectedInvalidateDocumentsCount,
                 ds.collectAsList().stream()
                     .filter(c -> c.get(c.fieldIndex("operationType")).equals("invalidate"))
                     .count(),
                 msg)));
   }
 
-  @Test
-  void testStreamWithFilter() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamWithFilter(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
 
-    testIdentifier = "WithFilter";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("WithFilter", collectionsConfigType);
     Column filterColumn = new Column("operationType").equalTo("insert");
     testStreamingQuery(
-        createMongoConfig()
+        createMongoConfig(collectionsConfigType)
             .withOption(
                 ReadConfig.READ_PREFIX + ReadConfig.STREAM_LOOKUP_FULL_DOCUMENT_CONFIG,
                 "updateLookup"),
@@ -171,15 +246,18 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(75, ds.collectAsList().size(), msg)));
   }
 
-  @Test
-  void testStreamWithPublishFullDocumentOnly() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamWithPublishFullDocumentOnly(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
 
-    testIdentifier = "FullDocOnly";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("FullDocOnly", collectionsConfigType);
 
     testStreamingQuery(
-        createMongoConfig()
+        createMongoConfig(collectionsConfigType)
             .withOption(
                 ReadConfig.READ_PREFIX + ReadConfig.STREAM_PUBLISH_FULL_DOCUMENT_ONLY_CONFIG,
                 "true")
@@ -218,14 +296,18 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
                 msg)));
   }
 
-  @Test
-  void testStreamPublishFullDocumentOnlyHandlesCollectionDrop() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamPublishFullDocumentOnlyHandlesCollectionDrop(
+      final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
 
-    testIdentifier = "FullDocOnlyWithDrop";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("FullDocOnlyWithDrop", collectionsConfigType);
     testStreamingQuery(
-        createMongoConfig()
+        createMongoConfig(collectionsConfigType)
             .withOption(
                 ReadConfig.READ_PREFIX + ReadConfig.STREAM_PUBLISH_FULL_DOCUMENT_ONLY_CONFIG,
                 "true")
@@ -244,13 +326,16 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(25, ds.collectAsList().size(), msg)));
   }
 
-  @Test
-  void testStreamResumable() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamResumable(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
-    testIdentifier = "Resumable";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("Resumable", collectionsConfigType);
 
-    MongoConfig mongoConfig = createMongoConfig();
+    MongoConfig mongoConfig = createMongoConfig(collectionsConfigType);
 
     testStreamingQuery(
         "mongodb",
@@ -261,7 +346,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(25, ds.countDocuments(), msg)));
 
     // Insert 50 documents - when there is no stream running
-    mongoConfig.toReadConfig().doWithCollection(coll -> coll.insertMany(createDocuments(100, 200)));
+    getCollection(collectionName()).insertMany(createDocuments(100, 200));
 
     // Start the stream again - confirm it resumes at last point and sees the new documents
     testStreamingQuery(
@@ -273,22 +358,27 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(125, ds.countDocuments(), msg)));
   }
 
-  @Test
-  void testStreamStartAtOperationTime() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamStartAtOperationTime(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
-    testIdentifier = "startAtOperationTime";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("startAtOperationTime", collectionsConfigType);
 
-    ReadConfig readConfig = createMongoConfig().toReadConfig();
+    ReadConfig readConfig = createMongoConfig(collectionsConfigType).toReadConfig();
+    MongoCollection<BsonDocument> collection = getCollection(collectionName());
 
     // Add some documents prior to the start time
-    readConfig.doWithCollection(coll -> coll.insertMany(createDocuments(0, 25)));
+    collection.insertMany(createDocuments(0, 25));
 
     HELPER.sleep(1000);
     BsonTimestamp currentTimestamp = new BsonTimestamp((int) Instant.now().getEpochSecond(), 0);
 
     // Add some documents post start time
-    readConfig.doWithCollection(coll -> coll.insertMany(createDocuments(100, 120)));
+
+    collection.insertMany(createDocuments(100, 120));
     testStreamingQuery(
         readConfig
             .withOption(ReadConfig.STREAMING_STARTUP_MODE_CONFIG, "timestamp")
@@ -301,12 +391,15 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(20, ds.collectAsList().size(), msg)));
   }
 
-  @Test
-  void testStreamCustomMongoClientFactory() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamCustomMongoClientFactory(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
-    testIdentifier = "CustomClientFactory";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("CustomClientFactory", collectionsConfigType);
     testStreamingQuery(
-        createMongoConfig()
+        createMongoConfig(collectionsConfigType)
             .withOption(
                 ReadConfig.PREFIX + ReadConfig.CLIENT_FACTORY_CONFIG,
                 "com.mongodb.spark.sql.connector.read.CustomMongoClientFactory"),
@@ -367,16 +460,21 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     assertTrue(cause.getMessage().contains("streams require a schema to be explicitly defined"));
   }
 
-  @Test
-  void testStreamInferSchemaWithDataPublishFullOnly() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamInferSchemaWithDataPublishFullOnly(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
-    testIdentifier = "inferSchemaWithDataPublishFullOnly";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier =
+        computeTestIdentifier("inferSchemaWithDataPublishFullOnly", collectionsConfigType);
 
-    ReadConfig readConfig = createMongoConfig()
+    ReadConfig readConfig = createMongoConfig(collectionsConfigType)
         .toReadConfig()
         .withOption(ReadConfig.STREAM_PUBLISH_FULL_DOCUMENT_ONLY_CONFIG, "true");
 
-    getCollection(readConfig.getCollectionName()).insertMany(createDocuments(0, 1));
+    withSource("inserting 0-1", (msg, coll) -> coll.insertMany(createDocuments(0, 1)))
+        .accept(readConfig);
     HELPER.sleep(1000);
 
     testStreamingQuery(
@@ -388,15 +486,18 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
             (msg, ds) -> assertEquals(25, ds.collectAsList().size(), msg)));
   }
 
-  @Test
-  void testStreamWriteStream() {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamWriteStream(final String collectionsConfigModeStr) {
     assumeTrue(supportsChangeStreams());
     assumeTrue(isAtLeastFourDotFour());
 
-    testIdentifier = "RoundTrip";
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("RoundTrip", collectionsConfigType);
     testStreamingQuery(
         "mongodb",
-        createMongoConfig(),
+        createMongoConfig(collectionsConfigType),
         withSource("inserting 0-25", (msg, coll) -> coll.insertMany(createDocuments(0, 25))),
         withSink(
             "Expected to see 25 documents",
@@ -410,10 +511,10 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
   @Test
   void testLogCommentsInProfilerLogs() {
     assumeTrue(supportsChangeStreams());
-
-    MongoConfig mongoConfig = createMongoConfig().withOption(PREFIX + COMMENT_CONFIG, TEST_COMMENT);
-
-    testIdentifier = "logsComments";
+    CollectionsConfig.Type collectionsConfigType = CollectionsConfig.Type.SINGLE;
+    testIdentifier = computeTestIdentifier("logsComments", collectionsConfigType);
+    MongoConfig mongoConfig =
+        createMongoConfig(collectionsConfigType).withOption(PREFIX + COMMENT_CONFIG, TEST_COMMENT);
 
     assertCommentsInProfile(
         () -> testStreamingQuery(
@@ -426,6 +527,54 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
                 "Expected to see 25 documents",
                 (msg, ds) -> assertEquals(25, ds.collectAsList().size(), msg))),
         mongoConfig.toReadConfig());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamHandlesDbDrop(final String collectionsConfigModeStr) {
+    assumeTrue(supportsChangeStreams());
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    testIdentifier = computeTestIdentifier("WithDbDrop", collectionsConfigType);
+    MongoConfig config = createMongoConfig(collectionsConfigType);
+    ReadConfig readConfig = config.toReadConfig();
+    Set<String> expectedEventTypes =
+        Stream.of("insert", "drop", "invalidate").collect(Collectors.toSet());
+    testStreamingQuery(
+        config,
+        withSource("inserting 0-3", (msg, coll) -> coll.insertMany(createDocuments(0, 3))),
+        withMemorySink(
+            "Expected to see 3 documents",
+            (msg, ds) -> assertEquals(3, ds.collectAsList().size(), msg)),
+        withSource(
+            format("Dropping the database `%s`", readConfig.getDatabaseName()),
+            (msg, coll) -> readConfig.doWithClient(
+                client -> client.getDatabase(readConfig.getDatabaseName()).drop())),
+        withMemorySink(
+            "Expected to see 1 drop document",
+            (msg, ds) -> assertEquals(
+                1,
+                ds.collectAsList().stream()
+                    .filter(c -> c.get(c.fieldIndex("operationType")).equals("drop"))
+                    .count(),
+                msg)),
+        withMemorySink(
+            "Expected to see 1 invalidate document",
+            (msg, ds) -> assertEquals(
+                1,
+                ds.collectAsList().stream()
+                    .filter(c -> c.get(c.fieldIndex("operationType")).equals("invalidate"))
+                    .count(),
+                msg)),
+        withMemorySink(
+            "Expected to see 0 documents of operation types other than " + expectedEventTypes,
+            (msg, ds) -> assertEquals(
+                0,
+                ds.collectAsList().stream()
+                    .filter(c ->
+                        !expectedEventTypes.contains(c.getString(c.fieldIndex("operationType"))))
+                    .count(),
+                msg)));
   }
 
   private static final StructType IGNORE_SCHEMA = createStructType(emptyList());
@@ -478,7 +627,8 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
       final Column condition,
       final Consumer<MongoConfig> setup,
       final Consumer<MongoConfig>... consumers) {
-
+    // see https://jira.mongodb.org/browse/SPARK-417 for the reason behind this call to `sleep`
+    HELPER.sleep(2000);
     StreamingQuery streamingQuery =
         createStreamingQuery(writeFormat, mongoConfig, schema, condition);
     try {
@@ -492,30 +642,32 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
         setup.accept(mongoConfig);
         LOGGER.info("Setup completed");
       } catch (Exception e) {
-        throw new AssertionFailedError("Setup failed: " + e.getMessage());
+        throw new AssertionFailedError("Setup failed: " + e.getMessage(), e);
       }
 
       for (Consumer<MongoConfig> consumer : consumers) {
 
         retryAssertion(() -> consumer.accept(mongoConfig), () -> {
-          mongoConfig
-              .toReadConfig()
-              .doWithCollection(coll -> LOGGER.info(
-                  "Source Collection Status: {}.",
-                  coll.find()
-                      .comment(IGNORE_COMMENT)
-                      .map(BsonDocument::toJson)
-                      .into(new ArrayList<>())));
+          withSource(
+                  null,
+                  (msg, coll) -> LOGGER.info(
+                      "Source Collection Status: {}.",
+                      coll.find()
+                          .comment(IGNORE_COMMENT)
+                          .map(BsonDocument::toJson)
+                          .into(new ArrayList<>())))
+              .accept(mongoConfig);
 
           if (writeFormat.equals(MONGODB)) {
-            mongoConfig
-                .toWriteConfig()
-                .doWithCollection(coll -> LOGGER.info(
-                    "Sink Collection Status: {}.",
-                    coll.find()
-                        .comment(IGNORE_COMMENT)
-                        .map(BsonDocument::toJson)
-                        .into(new ArrayList<>())));
+            withSink(
+                    null,
+                    (msg, coll) -> LOGGER.info(
+                        "Sink Collection Status: {}.",
+                        coll.find()
+                            .comment(IGNORE_COMMENT)
+                            .map(BsonDocument::toJson)
+                            .into(new ArrayList<>())))
+                .accept(mongoConfig);
           } else {
             LOGGER.info(
                 "Sink Memory Status: {}.",
@@ -525,8 +677,8 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
                     .stream()
                     .map(r -> Arrays.stream(r.schema().fields())
                         .map(f -> f.name() + ": " + r.get(r.fieldIndex(f.name())))
-                        .collect(Collectors.joining(", ", "{", "}")))
-                    .collect(Collectors.joining(", ", "[", "]")));
+                        .collect(joining(", ", "{", "}")))
+                    .collect(joining(", ", "[", "]")));
           }
         });
       }
@@ -576,18 +728,45 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
   }
 
   private Consumer<MongoConfig> withSource(
-      final String msg, final BiConsumer<String, MongoCollection<BsonDocument>> biConsumer) {
+      @Nullable final String msg,
+      final BiConsumer<String, MongoCollection<BsonDocument>> biConsumer) {
     return mongoConfig -> {
-      LOGGER.info("-> With source: " + msg);
-      mongoConfig.toReadConfig().doWithCollection(coll -> biConsumer.accept(msg, coll));
+      if (msg != null) {
+        LOGGER.info("-> With source: " + msg);
+      }
+      ReadConfig readConfig = mongoConfig.toReadConfig();
+      MongoCollection<BsonDocument> collection = readConfig.withClient(client -> client
+          .getDatabase(readConfig.getDatabaseName())
+          .getCollection(collectionName(), BsonDocument.class));
+      biConsumer.accept(msg, collection);
+    };
+  }
+
+  private Consumer<MongoConfig> withSourceDb(
+      @Nullable final String msg, final BiConsumer<String, MongoDatabase> biConsumer) {
+    return mongoConfig -> {
+      if (msg != null) {
+        LOGGER.info("-> With source: " + msg);
+      }
+      ReadConfig readConfig = mongoConfig.toReadConfig();
+      MongoDatabase db =
+          readConfig.withClient(client -> client.getDatabase(readConfig.getDatabaseName()));
+      biConsumer.accept(msg, db);
     };
   }
 
   private Consumer<MongoConfig> withSink(
-      final String msg, final BiConsumer<String, MongoCollection<BsonDocument>> biConsumer) {
+      @Nullable final String msg,
+      final BiConsumer<String, MongoCollection<BsonDocument>> biConsumer) {
     return mongoConfig -> {
-      LOGGER.info("-> With sink: " + msg);
-      mongoConfig.toWriteConfig().doWithCollection(coll -> biConsumer.accept(msg, coll));
+      if (msg != null) {
+        LOGGER.info("-> With sink: " + msg);
+      }
+      WriteConfig writeConfig = mongoConfig.toWriteConfig();
+      MongoCollection<BsonDocument> collection = writeConfig.withClient(client -> client
+          .getDatabase(writeConfig.getDatabaseName())
+          .getCollection(collectionName(), BsonDocument.class));
+      biConsumer.accept(msg, collection);
     };
   }
 
@@ -599,14 +778,37 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     };
   }
 
-  private MongoConfig createMongoConfig() {
+  private MongoConfig createMongoConfig(final CollectionsConfig.Type collectionsConfigType) {
     Map<String, String> options = new HashMap<>();
     Arrays.stream(getSparkConf().getAllWithPrefix(MongoConfig.PREFIX))
         .forEach(t -> options.put(MongoConfig.PREFIX + t._1(), t._2()));
+    String collectionsConfigOptionValue;
+    switch (collectionsConfigType) {
+      case SINGLE:
+        collectionsConfigOptionValue = collectionName();
+        break;
+      case MULTIPLE:
+        collectionsConfigOptionValue =
+            join(",", "collectionNameThatDoesNotExist", collectionName());
+        break;
+      case ALL:
+        collectionsConfigOptionValue = "*";
+        break;
+      default:
+        throw com.mongodb.assertions.Assertions.fail();
+    }
     options.put(
-        ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG,
-        collectionPrefix() + "Source" + testIdentifier);
+        ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG, collectionsConfigOptionValue);
     return MongoConfig.createConfig(options);
+  }
+
+  private static String computeTestIdentifier(
+      final String testIdentifierStart, final CollectionsConfig.Type collectionsConfigType) {
+    return testIdentifierStart + "_" + collectionsConfigType;
+  }
+
+  private String collectionName() {
+    return collectionPrefix() + "Source" + testIdentifier;
   }
 
   private List<BsonDocument> createDocuments(final int startInclusive, final int endExclusive) {

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/schema/InferSchemaIntegrationTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/schema/InferSchemaIntegrationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.schema;
+
+import static com.mongodb.assertions.Assertions.fail;
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static org.apache.spark.sql.types.DataTypes.createStructField;
+import static org.apache.spark.sql.types.DataTypes.createStructType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.spark.sql.connector.config.CollectionsConfig;
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.mongodb.MongoSparkConnectorTestCase;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class InferSchemaIntegrationTest extends MongoSparkConnectorTestCase {
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void inferSchema(final String collectionsConfigModeStr) {
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    String collectionNamePrefix = "inferSchemaFromMultipleCollections_" + collectionsConfigType;
+    String collectionName1 = collectionNamePrefix + "_1";
+    String collectionName2 = collectionNamePrefix + "_2";
+    String collectionName3 = collectionNamePrefix + "_3";
+    StructField id =
+        createStructField("_id", DataTypes.StringType, true, InferSchema.INFERRED_METADATA);
+    StructField a =
+        createStructField("a", DataTypes.IntegerType, true, InferSchema.INFERRED_METADATA);
+    StructField b =
+        createStructField("b", DataTypes.StringType, true, InferSchema.INFERRED_METADATA);
+    StructField c =
+        createStructField("c", DataTypes.BooleanType, true, InferSchema.INFERRED_METADATA);
+    StructType expectedSchema;
+    String collectionNameOptionValue;
+    switch (collectionsConfigType) {
+      case SINGLE:
+        expectedSchema = createStructType(asList(id, a));
+        collectionNameOptionValue = collectionName1;
+        break;
+      case MULTIPLE:
+        expectedSchema = createStructType(asList(id, a, c));
+        collectionNameOptionValue = join(",", collectionName1, collectionName3);
+        break;
+      case ALL:
+        expectedSchema = createStructType(asList(id, a, b, c));
+        collectionNameOptionValue = "*";
+        break;
+      default:
+        throw fail();
+    }
+    ReadConfig readConfig = getMongoConfig()
+        .withOption(
+            ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG, collectionNameOptionValue)
+        .toReadConfig();
+    readConfig.withClient(client -> {
+      MongoDatabase database = client.getDatabase(readConfig.getDatabaseName());
+      database
+          .getCollection(collectionName1, BsonDocument.class)
+          .insertOne(new BsonDocument("a", new BsonInt32(0)));
+      database
+          .getCollection(collectionName2, BsonDocument.class)
+          .insertOne(new BsonDocument("b", new BsonString("")));
+      database
+          .getCollection(collectionName3, BsonDocument.class)
+          .insertOne(new BsonDocument("c", BsonBoolean.FALSE));
+      return null;
+    });
+    StructType actualSchema =
+        InferSchema.inferSchema(new CaseInsensitiveStringMap(readConfig.getOptions()));
+    assertEquals(expectedSchema, actualSchema);
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/MongoTable.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/MongoTable.java
@@ -95,10 +95,13 @@ final class MongoTable implements Table, SupportsWrite, SupportsRead {
   /** The name of this table. */
   @Override
   public String name() {
-    if (mongoConfig instanceof ReadConfig || mongoConfig instanceof WriteConfig) {
-      return "MongoTable(" + mongoConfig.getNamespace() + ")";
+    if (mongoConfig instanceof ReadConfig) {
+      return "MongoTable(" + mongoConfig.toReadConfig().getNamespaceDescription() + ")";
+    } else if (mongoConfig instanceof WriteConfig) {
+      return "MongoTable(" + mongoConfig.toWriteConfig().getNamespaceDescription() + ")";
+    } else {
+      return "MongoTable()";
     }
-    return "MongoTable()";
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/config/AbstractMongoConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/AbstractMongoConfig.java
@@ -131,7 +131,12 @@ abstract class AbstractMongoConfig implements MongoConfig {
   }
 
   /**
-   * @see #getNamespace()
+   * @return The namespace description, which is equal to the {@linkplain MongoNamespace#toString() string representation}
+   * of {@link #getNamespace()} when a {@linkplain CollectionsConfig.Type#SINGLE single}
+   * collection is {@linkplain ReadConfig#getCollectionsConfig() configured} to be {@linkplain Scan scanned}.
+   * Unlike {@link #getNamespace()}, this method works even if
+   * {@linkplain CollectionsConfig.Type#MULTIPLE multiple} or {@linkplain CollectionsConfig.Type#ALL all}
+   * collections are configured to be scanned.
    */
   @ApiStatus.Internal
   public String getNamespaceDescription() {
@@ -141,6 +146,7 @@ abstract class AbstractMongoConfig implements MongoConfig {
   }
 
   /**
+   * @return The {@link CollectionsConfig}.
    * @see #getCollectionName()
    */
   @ApiStatus.Internal

--- a/src/main/java/com/mongodb/spark/sql/connector/config/CollectionsConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/CollectionsConfig.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.config;
+
+import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.assertions.Assertions.fail;
+import static java.lang.String.format;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.StreamSupport.stream;
+
+import com.mongodb.spark.sql.connector.MongoTableProvider;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A configuration of the set of collections for {@linkplain Scan scanning} from.
+ *
+ * @see AbstractMongoConfig#getCollectionsConfig()
+ * @see MongoConfig#getCollectionName()
+ * @see AbstractMongoConfig#COLLECTION_NAME_CONFIG
+ */
+@ApiStatus.Internal
+public final class CollectionsConfig {
+  private static final char ALL_PATTERN = '*';
+
+  private final Set<String> names;
+
+  static CollectionsConfig parse(final String raw) throws ParsingException {
+    assertNotNull(raw);
+    assertFalse(raw.isEmpty());
+    final Set<String> names;
+    if (raw.length() == 1 && raw.charAt(0) == ALL_PATTERN) {
+      names = emptySet();
+    } else {
+      names = stream(new CollectionNameSpliterator(raw), false).collect(Collectors.toSet());
+      assertFalse(names.isEmpty());
+    }
+    return new CollectionsConfig(names);
+  }
+
+  private CollectionsConfig(final Set<String> names) {
+    this.names = unmodifiableSet(names);
+  }
+
+  /**
+   * Gets the type of the configuration.
+   * @return The type of the configuration.
+   */
+  @ApiStatus.Internal
+  public Type getType() {
+    if (names.isEmpty()) {
+      return Type.ALL;
+    } else if (names.size() == 1) {
+      return Type.SINGLE;
+    } else {
+      return Type.MULTIPLE;
+    }
+  }
+
+  String getName() {
+    assertTrue(getType() == Type.SINGLE);
+    return names.iterator().next();
+  }
+
+  /**
+   * It is {@linkplain Collection#isEmpty() empty} iff {@link #getType()} is {@link CollectionsConfig.Type#ALL},
+   * because in this case the collections are detected automatically and the set of collections may change while scanning,
+   * if collections are created or dropped.
+   *
+   * @return An unmodifiable {@link Collection}.
+   */
+  @ApiStatus.Internal
+  public Collection<String> getNames() {
+    return names;
+  }
+
+  String getPartialNamespaceDescription() {
+    switch (getType()) {
+      case SINGLE:
+        return getName();
+      case MULTIPLE:
+        return names.toString();
+      case ALL:
+        return String.valueOf(ALL_PATTERN);
+      default:
+        throw fail();
+    }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CollectionsConfig that = (CollectionsConfig) o;
+    return Objects.equals(names, that.names);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(names);
+  }
+
+  /**
+   * The type of {@link CollectionsConfig}.
+   * Some types may not be supported by some {@linkplain Scan scanning} modes.
+   */
+  @ApiStatus.Internal
+  public enum Type {
+    /**
+     * Scan a {@linkplain MongoConfig#getCollectionName() single collection}.
+     * This type is supported by
+     * {@linkplain Scan#toBatch() batch queries},
+     * {@linkplain Scan#toMicroBatchStream(String) micro-batch streams},
+     * {@linkplain Scan#toContinuousStream(String) continuous streams}.
+     */
+    @ApiStatus.Internal
+    SINGLE,
+    /**
+     * Scan multiple collections.
+     * This type is supported by
+     * {@linkplain Scan#toMicroBatchStream(String) micro-batch streams},
+     * {@linkplain Scan#toContinuousStream(String) continuous streams}.
+     */
+    @ApiStatus.Internal
+    MULTIPLE,
+    /**
+     * Scan all collections in the {@linkplain MongoConfig#getDatabaseName() database}.
+     * This type is supported by
+     * {@linkplain Scan#toMicroBatchStream(String) micro-batch streams},
+     * {@linkplain Scan#toContinuousStream(String) continuous streams}.
+     * <p>
+     * {@linkplain MongoTableProvider#inferSchema(CaseInsensitiveStringMap) Schema inference} happens at the beginning
+     * of scanning, and does not take into account collections that may be created while scanning, despite those collections being
+     * scanned after being created. If you want to scan a fixed set of collections, use {@link #MULTIPLE}.</p>
+     */
+    @ApiStatus.Internal
+    ALL
+  }
+
+  static final class ParsingException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private ParsingException(final String message) {
+      super(message);
+    }
+  }
+
+  private static final class CollectionNameSpliterator implements Spliterator<String> {
+    private static final char SEPARATOR = ',';
+    private static final char ESCAPE = '\\';
+    private static final char[] ESCAPABLE = {SEPARATOR, ESCAPE, ALL_PATTERN};
+
+    private final String source;
+    private int lastParsedIdx;
+
+    CollectionNameSpliterator(final String source) {
+      assertFalse(source.isEmpty());
+      this.source = source;
+      lastParsedIdx = -1;
+    }
+
+    @Override
+    public boolean tryAdvance(final Consumer<? super String> action) throws ParsingException {
+      int lastIdx = source.length() - 1;
+      if (lastParsedIdx == lastIdx) {
+        return false;
+      }
+      StringBuilder elementBuilder = new StringBuilder();
+      while (true) {
+        int fistUnparsedIdx = lastParsedIdx + 1;
+        int separatorIdx = source.indexOf(SEPARATOR, fistUnparsedIdx);
+        int escapeIdx = source.indexOf(ESCAPE, fistUnparsedIdx);
+        if (separatorIdx < 0 && escapeIdx < 0) {
+          // the current element is the last one
+          elementBuilder.append(source, fistUnparsedIdx, lastIdx + 1);
+          lastParsedIdx = lastIdx;
+          break;
+        }
+        assertFalse(separatorIdx == escapeIdx);
+        if (escapeIdx < 0 || (separatorIdx >= 0 && separatorIdx < escapeIdx)) {
+          // parse up to the `separatorIdx`, as nothing is escaped in the current element
+          if ((fistUnparsedIdx == separatorIdx && elementBuilder.length() == 0)
+              || separatorIdx == lastIdx) {
+            throw emptyElementException(separatorIdx);
+          }
+          elementBuilder.append(source, fistUnparsedIdx, separatorIdx);
+          lastParsedIdx = separatorIdx;
+          break;
+        } else {
+          // unescape and continue parsing the current element
+          if (escapeIdx == lastIdx) {
+            throw lonelyEscapeException(escapeIdx);
+          }
+          int escapedIdx = escapeIdx + 1;
+          char escaped = source.charAt(escapedIdx);
+          if (escapable(escaped)) {
+            elementBuilder.append(source, fistUnparsedIdx, escapeIdx).append(escaped);
+            lastParsedIdx = escapedIdx;
+          } else {
+            throw unescapableException(escaped, escapedIdx);
+          }
+        }
+      }
+      assertFalse(elementBuilder.length() == 0);
+      action.accept(elementBuilder.toString());
+      return true;
+    }
+
+    @Override
+    public Spliterator<String> trySplit() {
+      return null;
+    }
+
+    @Override
+    public long estimateSize() {
+      return Long.MAX_VALUE;
+    }
+
+    @Override
+    public int characteristics() {
+      return IMMUTABLE | NONNULL;
+    }
+
+    private static boolean escapable(final char c) {
+      for (char escapable : ESCAPABLE) {
+        if (c == escapable) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private ParsingException emptyElementException(final int separatorIdx) {
+      return new ParsingException(format(
+          "Empty elements are not allowed. Something is wrong at the index %d: \"%s\"",
+          separatorIdx, source));
+    }
+
+    private ParsingException lonelyEscapeException(final int escapeIdx) {
+      return new ParsingException(format(
+          "The '%c' character at the index %d does not escape anything: \"%s\"",
+          ESCAPE, escapeIdx, source));
+    }
+
+    private ParsingException unescapableException(final char escaped, final int escapedIdx) {
+      throw new ParsingException(format(
+          "The '%c' character at the index %d must not be escaped: \"%s\"",
+          escaped, escapedIdx, source));
+    }
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.connector.read.Scan;
-import org.apache.spark.sql.connector.write.Write;
+import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.bson.BsonString;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -153,9 +153,11 @@ public interface MongoConfig extends Serializable {
    */
   String DATABASE_NAME_CONFIG = "database";
 
+  // This documentation links to `WriteBuilder` instead of `Write`
+  // because `Write` was added in park-catalyst 3.2.0, and we must support 3.1.2.
   /**
-   * A configuration of the set of collections for {@linkplain Write writing} to / {@linkplain Scan scanning} from.
-   * When configuring a {@linkplain Write write}, only a single collection name is supported.
+   * A configuration of the set of collections for {@linkplain WriteBuilder writing} to / {@linkplain Scan scanning} from.
+   * When configuring a {@linkplain WriteBuilder write}, only a single collection name is supported.
    * When configuring a {@linkplain Scan scan},
    * the following {@linkplain CollectionsConfig.Type configuration types} are supported:
    * <ul>

--- a/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
@@ -154,7 +154,7 @@ public interface MongoConfig extends Serializable {
   String DATABASE_NAME_CONFIG = "database";
 
   // This documentation links to `WriteBuilder` instead of `Write`
-  // because `Write` was added in park-catalyst 3.2.0, and we must support 3.1.2.
+  // because `Write` was added in spark-catalyst 3.2.0, and we must support 3.1.2.
   /**
    * A configuration of the set of collections for {@linkplain WriteBuilder writing} to / {@linkplain Scan scanning} from.
    * When configuring a {@linkplain WriteBuilder write}, only a single collection name is supported.

--- a/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.connector.write.Write;
 import org.bson.BsonString;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -152,7 +154,35 @@ public interface MongoConfig extends Serializable {
   String DATABASE_NAME_CONFIG = "database";
 
   /**
-   * The collection name config
+   * A configuration of the set of collections for {@linkplain Write writing} to / {@linkplain Scan scanning} from.
+   * When configuring a {@linkplain Write write}, only a single collection name is supported.
+   * When configuring a {@linkplain Scan scan},
+   * the following {@linkplain CollectionsConfig.Type configuration types} are supported:
+   * <ul>
+   *     <li>
+   *     A {@linkplain CollectionsConfig.Type#SINGLE single} collection name.</li>
+   *     <li>
+   *     {@linkplain CollectionsConfig.Type#MULTIPLE Multiple} collection names separated with comma ({@code ','}).
+   *     For example, {@code "collectionA,collectionB"}.
+   *     Note how the values are separated only with comma, and there is no space ({@code ' '}) accompanying it.
+   *     Specifying a space makes it part of a collection name:
+   *     {@code "collectionA, collectionB"}---collections {@code "collectionA"} and {@code " collectionB"}.</li>
+   *     <li>
+   *     {@linkplain CollectionsConfig.Type#ALL All} collections in the {@linkplain #getDatabaseName() database},
+   *     in which case one must specify a string consisting of a single asterisk ({@code '*'}).</li>
+   * </ul>
+   * Note that if a collection name contains comma ({@code ','}), reverse solidus ({@code '\'}), or starts with asterisk ({@code '*'}),
+   * such a character must be escaped with reverse solidus ({@code '\'}). Examples:
+   * <ul>
+   *     <li>
+   *     {@code "mass\, kg"}---a single collection named {@code "mass, kg"}.</li>
+   *     <li>
+   *     {@code "\*"}---a single collection named {@code "*"}.</li>
+   *     <li>
+   *     {@code "\\"}---a single collection named {@code "\"}.
+   *     Note that if the value is specified as a string literal in Java code, then each reverse solidus has to be further escaped,
+   *     leading to having to specify {@code "\\\\"}.</li>
+   * </ul>
    *
    * <p>{@value}
    */
@@ -204,7 +234,12 @@ public interface MongoConfig extends Serializable {
     return new ConnectionString(getOrDefault(CONNECTION_STRING_CONFIG, CONNECTION_STRING_DEFAULT));
   }
 
-  /** @return the namespace related to this config */
+  /**
+   * @return the namespace related to this config
+   * @throws ConfigException
+   * If either {@linkplain CollectionsConfig.Type#MULTIPLE multiple} or {@linkplain CollectionsConfig.Type#ALL all}
+   * collections are {@linkplain ReadConfig#getCollectionsConfig() configured} to be {@linkplain Scan scanned}.
+   */
   default MongoNamespace getNamespace() {
     return new MongoNamespace(getDatabaseName(), getCollectionName());
   }

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -79,7 +79,9 @@ public final class ReadConfig extends AbstractMongoConfig {
   public static final String PARTITIONER_OPTIONS_PREFIX = "partitioner.options.";
 
   /**
-   * The size of the sample of documents from the collection to use when inferring the schema
+   * The size of the sample of documents from the collection to use when inferring the schema.
+   * When inferring from {@linkplain CollectionsConfig.Type#MULTIPLE multiple} or {@linkplain CollectionsConfig.Type#ALL all} collections,
+   * each collection is sampled with this size.
    *
    * <p>Configuration: {@value}
    *

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousPartitionReader.java
@@ -25,6 +25,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 import com.mongodb.spark.sql.connector.assertions.Assertions;
+import com.mongodb.spark.sql.connector.config.CollectionsConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import com.mongodb.spark.sql.connector.schema.BsonDocumentToRowConverter;
@@ -169,10 +170,17 @@ final class MongoContinuousPartitionReader implements ContinuousPartitionReader<
         pipeline.add(Aggregates.match(Filters.exists(FULL_DOCUMENT)).toBsonDocument());
       }
       pipeline.addAll(partition.getPipeline());
-      ChangeStreamIterable<Document> changeStreamIterable = mongoClient
-          .getDatabase(readConfig.getDatabaseName())
-          .getCollection(readConfig.getCollectionName())
-          .watch(pipeline)
+      ChangeStreamIterable<Document> changeStreamIterable;
+      if (readConfig.getCollectionsConfig().getType() == CollectionsConfig.Type.SINGLE) {
+        changeStreamIterable = mongoClient
+            .getDatabase(readConfig.getDatabaseName())
+            .getCollection(readConfig.getCollectionName())
+            .watch(pipeline);
+      } else {
+        changeStreamIterable =
+            mongoClient.getDatabase(readConfig.getDatabaseName()).watch(pipeline);
+      }
+      changeStreamIterable
           .fullDocument(readConfig.getStreamFullDocument())
           .comment(readConfig.getComment());
       changeStreamIterable = lastOffset.applyToChangeStreamIterable(changeStreamIterable);

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoInputPartitionHelper.java
@@ -16,14 +16,21 @@
  */
 package com.mongodb.spark.sql.connector.read;
 
+import static com.mongodb.assertions.Assertions.fail;
 import static com.mongodb.spark.sql.connector.read.partitioner.Partitioner.LOGGER;
 import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.SINGLE_PARTITIONER;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import com.mongodb.spark.sql.connector.config.CollectionsConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import com.mongodb.spark.sql.connector.read.partitioner.Partitioner;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -111,9 +118,14 @@ final class MongoInputPartitionHelper {
   }
 
   static List<BsonDocument> generatePipeline(final StructType schema, final ReadConfig readConfig) {
-    return schemaProjections(schema, readConfig.streamPublishFullDocumentOnly())
+    ArrayList<BsonDocument> result =
+        new ArrayList<>(collectionsConfigPipeline(readConfig.getCollectionsConfig()));
+    List<BsonDocument> customPipelineAndSchemaProjections = schemaProjections(
+            schema, readConfig.streamPublishFullDocumentOnly())
         .map(mergePipelineFunction(readConfig.getAggregationPipeline()))
         .orElse(readConfig.getAggregationPipeline());
+    result.addAll(customPipelineAndSchemaProjections);
+    return result;
   }
 
   private static Optional<BsonDocument> schemaProjections(
@@ -137,6 +149,31 @@ final class MongoInputPartitionHelper {
       pipelineWithSchemaProjection.add(projectionStage);
       return pipelineWithSchemaProjection;
     };
+  }
+
+  /**
+   * Returns the stages of the aggregation pipeline
+   * that are to be used before any other stages in order to account for the {@code collectionsConfig}.
+   */
+  private static Collection<BsonDocument> collectionsConfigPipeline(
+      final CollectionsConfig collectionsConfig) {
+    // note that `invalidate` events do not have the `ns.coll` field,
+    // so we have to explicitly allow them in the filter
+    switch (collectionsConfig.getType()) {
+      case SINGLE:
+        return emptyList();
+      case MULTIPLE:
+        return singletonList(Aggregates.match(Filters.or(
+                Filters.in("ns.coll", collectionsConfig.getNames().toArray()),
+                Filters.in("operationType", "invalidate")))
+            .toBsonDocument());
+      case ALL:
+        return singletonList(Aggregates.match(
+                Filters.or(Filters.exists("ns.coll"), Filters.in("operationType", "invalidate")))
+            .toBsonDocument());
+      default:
+        throw fail();
+    }
   }
 
   private MongoInputPartitionHelper() {}

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
@@ -25,6 +25,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.Filters;
 import com.mongodb.spark.sql.connector.assertions.Assertions;
+import com.mongodb.spark.sql.connector.config.CollectionsConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import com.mongodb.spark.sql.connector.schema.BsonDocumentToRowConverter;
@@ -166,10 +167,17 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
         pipeline.add(Aggregates.match(Filters.exists(FULL_DOCUMENT)).toBsonDocument());
       }
       pipeline.addAll(partition.getPipeline());
-      ChangeStreamIterable<Document> changeStreamIterable = mongoClient
-          .getDatabase(readConfig.getDatabaseName())
-          .getCollection(readConfig.getCollectionName())
-          .watch(pipeline)
+      ChangeStreamIterable<Document> changeStreamIterable;
+      if (readConfig.getCollectionsConfig().getType() == CollectionsConfig.Type.SINGLE) {
+        changeStreamIterable = mongoClient
+            .getDatabase(readConfig.getDatabaseName())
+            .getCollection(readConfig.getCollectionName())
+            .watch(pipeline);
+      } else {
+        changeStreamIterable =
+            mongoClient.getDatabase(readConfig.getDatabaseName()).watch(pipeline);
+      }
+      changeStreamIterable
           .fullDocument(readConfig.getStreamFullDocument())
           .comment(readConfig.getComment());
       if (partition.getStartOffsetTimestamp().getTime() >= 0) {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoScan.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoScan.java
@@ -52,10 +52,15 @@ final class MongoScan implements Scan {
   /** A description string of this scan. */
   @Override
   public String description() {
-    return "MongoScan{" + "namespace=" + readConfig.getNamespace().toString() + '}';
+    return "MongoScan{" + "namespaceDescription=" + readConfig.getNamespaceDescription() + '}';
   }
 
-  /** Returns the physical representation of this scan for batch query. */
+  /**
+   * Returns the physical representation of this scan for batch query.
+   * This mode does not support scanning
+   * {@linkplain com.mongodb.spark.sql.connector.config.CollectionsConfig.Type#MULTIPLE multiple} or
+   * {@linkplain com.mongodb.spark.sql.connector.config.CollectionsConfig.Type#ALL all} collections.
+   */
   @Override
   public Batch toBatch() {
     return new MongoBatch(schema, readConfig);

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/PartitionerHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/PartitionerHelper.java
@@ -23,11 +23,13 @@ import static java.util.Collections.singletonList;
 import com.mongodb.MongoCommandException;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.exceptions.ConfigException;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.spark.sql.connector.read.Scan;
 import org.bson.BsonDocument;
 import org.bson.BsonType;
 import org.bson.BsonValue;
@@ -91,6 +93,10 @@ public final class PartitionerHelper {
   /**
    * @param readConfig the read config
    * @return the storage stats or an empty document if the collection does not exist
+   * @throws ConfigException
+   * If either {@linkplain com.mongodb.spark.sql.connector.config.CollectionsConfig.Type#MULTIPLE multiple}
+   * or {@linkplain com.mongodb.spark.sql.connector.config.CollectionsConfig.Type#ALL all}
+   * collections are {@linkplain ReadConfig#getCollectionsConfig() configured} to be {@linkplain Scan scanned}.
    */
   public static BsonDocument storageStats(final ReadConfig readConfig) {
     LOGGER.info("Getting collection stats for: {}", readConfig.getNamespace().getFullName());

--- a/src/test/java/com/mongodb/spark/sql/connector/config/CollectionsConfigTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/config/CollectionsConfigTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.config;
+
+import static com.mongodb.spark.sql.connector.config.CollectionsConfig.Type.ALL;
+import static com.mongodb.spark.sql.connector.config.CollectionsConfig.Type.MULTIPLE;
+import static com.mongodb.spark.sql.connector.config.CollectionsConfig.Type.SINGLE;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.lang.Nullable;
+import com.mongodb.spark.sql.connector.config.CollectionsConfig.ParsingException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+final class CollectionsConfigTest {
+  @Test
+  void parse() {
+    String emptyElementMessage = "Empty elements are not allowed";
+    String lonelyEscapeMessage = "does not escape anything";
+    String unescapableMessage = "must not be escaped";
+    assertAll(
+        () -> assertThrows(AssertionError.class, () -> CollectionsConfig.parse(null)),
+        () -> assertThrows(AssertionError.class, () -> CollectionsConfig.parse("")),
+        () -> assertParse(emptyElementMessage, ","),
+        () -> assertParse(emptyElementMessage, ",,"),
+        () -> assertParse(emptyElementMessage, "a,,b"),
+        () -> assertParse(emptyElementMessage, "a,"),
+        () -> assertParse(emptyElementMessage, ",a"),
+        () -> assertParse(emptyElementMessage, ",a,b"),
+        () -> assertParse(emptyElementMessage, "a,b,"),
+        () -> assertParse(lonelyEscapeMessage, "\\"),
+        () -> assertParse(lonelyEscapeMessage, "a\\"),
+        () -> assertParse(unescapableMessage, "\\a"),
+        () -> assertParse(lonelyEscapeMessage, "a,b\\"),
+        () -> assertParse(unescapableMessage, "\\ab"),
+        () -> assertParse(ALL, of(), "*"),
+        () -> assertParse(SINGLE, of("*"), "\\*"),
+        () -> assertParse(SINGLE, of("**"), "**"),
+        () -> assertParse(SINGLE, of("*"), "*,*"),
+        () -> assertParse(SINGLE, of("*"), "\\*,\\*"),
+        () -> assertParse(MULTIPLE, of("*", "**"), "*,**"),
+        () -> assertParse(SINGLE, of("\\"), "\\\\"),
+        () -> assertParse(SINGLE, of(" "), " "),
+        () -> assertParse(MULTIPLE, of("ab*c.d e", " ", "f,g", "\\h"), "ab*c.d e, ,f\\,g,\\\\h"));
+  }
+
+  private static void assertParse(final String expectedMessage, @Nullable final String unparsed) {
+    String actualMessage = assertThrows(
+            ParsingException.class, () -> CollectionsConfig.parse(unparsed))
+        .getMessage();
+    assertTrue(
+        actualMessage.contains(expectedMessage),
+        format("The message \"%s\" does not contain \"%s\"", actualMessage, expectedMessage));
+  }
+
+  private static void assertParse(
+      final CollectionsConfig.Type expectedType,
+      final Set<String> expectedNames,
+      final String unparsed) {
+    CollectionsConfig actual = CollectionsConfig.parse(unparsed);
+    assertEquals(expectedType, actual.getType());
+    assertEquals(expectedNames, actual.getNames());
+  }
+
+  private static Set<String> of(final String... elements) {
+    return Stream.of(elements).collect(Collectors.toSet());
+  }
+}

--- a/src/test/java/com/mongodb/spark/sql/connector/config/MongoConfigTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/config/MongoConfigTest.java
@@ -214,6 +214,29 @@ public class MongoConfigTest {
     writeConfig = MongoConfig.writeConfig(options);
     assertEquals("overriddenWriteDb", writeConfig.getDatabaseName());
     assertEquals("overriddenWriteColl", writeConfig.getCollectionName());
+
+    // CollectionsConfig.Mode.MULTIPLE
+    options.put(
+        MongoConfig.READ_PREFIX + MongoConfig.COLLECTION_NAME_CONFIG, "readCollA,readCollB");
+    options.put(
+        MongoConfig.WRITE_PREFIX + MongoConfig.COLLECTION_NAME_CONFIG, "writeCollA,writeCollB");
+    assertEquals(
+        CollectionsConfig.parse("readCollA,readCollB"),
+        MongoConfig.readConfig(options).getCollectionsConfig());
+    assertThrows(ConfigException.class, () -> MongoConfig.readConfig(options).getCollectionName());
+    assertThrows(
+        ConfigException.class, () -> MongoConfig.writeConfig(options).getCollectionsConfig());
+    assertThrows(ConfigException.class, () -> MongoConfig.writeConfig(options).getCollectionName());
+
+    // CollectionsConfig.Mode.ALL
+    options.put(MongoConfig.READ_PREFIX + MongoConfig.COLLECTION_NAME_CONFIG, "*");
+    options.put(MongoConfig.WRITE_PREFIX + MongoConfig.COLLECTION_NAME_CONFIG, "*");
+    assertEquals(
+        CollectionsConfig.parse("*"), MongoConfig.readConfig(options).getCollectionsConfig());
+    assertThrows(ConfigException.class, () -> MongoConfig.readConfig(options).getCollectionName());
+    assertThrows(
+        ConfigException.class, () -> MongoConfig.writeConfig(options).getCollectionsConfig());
+    assertThrows(ConfigException.class, () -> MongoConfig.writeConfig(options).getCollectionName());
   }
 
   @ParameterizedTest

--- a/src/test/java/com/mongodb/spark/sql/connector/read/MongoScanTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/read/MongoScanTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.read;
+
+import static java.util.Collections.emptyList;
+import static org.apache.spark.sql.types.DataTypes.createStructType;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.mongodb.spark.sql.connector.config.MongoConfig;
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.exceptions.ConfigException;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class MongoScanTest {
+  @Test
+  void toBatch() {
+    assertAll(
+        () -> assertThrows(ConfigException.class, () -> new MongoScan(
+                createStructType(emptyList()),
+                MongoConfig.readConfig(Collections.singletonMap(
+                    ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG, "*")))
+            .toBatch()),
+        () -> assertThrows(ConfigException.class, () -> new MongoScan(
+                createStructType(emptyList()),
+                MongoConfig.readConfig(Collections.singletonMap(
+                    ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG, "a,b")))
+            .toBatch()),
+        () -> assertDoesNotThrow(() -> new MongoScan(
+                createStructType(emptyList()),
+                MongoConfig.readConfig(Collections.singletonMap(
+                    ReadConfig.READ_PREFIX + ReadConfig.COLLECTION_NAME_CONFIG, "a")))
+            .toBatch()));
+  }
+}


### PR DESCRIPTION
For the description of the new functionality and configuration see the API documentation of the following program elements:

- `MongoConfig.COLLECTION_NAME_CONFIG`
- `CollectionsConfig.Type` and its values.

For the complete picture, please see also [this](https://jira.mongodb.org/browse/SPARK-404?focusedCommentId=6018950&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6018950) comment.

Note that I marked all the new `public` program elements as `@ApiStatus.Internal`. I am not sure whether that is correct, but I don't see myself why they need to be part of the API, nor do I see why all the existing program elements that allow accessing the configuration for reading had to be made part of the API previously.

SPARK-404