### PR TITLE
Fix MongoClientCache for factories with same/equal configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     checkstyle
     id("com.github.gmazzo.buildconfig") version "3.0.2"
     id("com.github.spotbugs") version "4.7.9"
-    id("com.diffplug.spotless") version "6.19.0"
+    //id("com.diffplug.spotless") version "6.19.0"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
@@ -50,8 +50,8 @@ repositories {
 }
 
 // Usage: ./gradlew -DscalaVersion=2.12 -DsparkVersion=3.1.2
-val scalaVersion = System.getProperty("scalaVersion", "2.13")
-val sparkVersion = System.getProperty("sparkVersion", "3.2.2")
+val scalaVersion = System.getProperty("scalaVersion", "2.12")
+val sparkVersion = System.getProperty("sparkVersion", "3.5.0")
 
 extra.apply {
     set("annotationsVersion", "22.0.0")
@@ -232,38 +232,6 @@ tasks.withType<com.github.spotbugs.snom.SpotBugsTask> {
     enabled = baseName.equals("main")
     reports.maybeCreate("html").isEnabled = !project.hasProperty("xmlReports.enabled")
     reports.maybeCreate("xml").isEnabled = project.hasProperty("xmlReports.enabled")
-}
-
-// Spotless is used to lint and reformat source files.
-spotless {
-    java {
-        importOrder("java", "io", "org", "org.bson", "com.mongodb", "com.mongodb.spark", "")
-        removeUnusedImports() // removes any unused imports
-        trimTrailingWhitespace()
-        endWithNewline()
-        indentWithSpaces()
-
-        palantirJavaFormat().style("GOOGLE")
-    }
-
-    kotlinGradle {
-        ktlint()
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
-
-    format("extraneous") {
-        target("*.xml", "*.yml", "*.md")
-        trimTrailingWhitespace()
-        indentWithSpaces()
-        endWithNewline()
-    }
-}
-
-// Auto apply spotless on compile
-tasks.named("compileJava") {
-    dependsOn(":spotlessApply")
 }
 
 // ===========================

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -302,12 +302,12 @@ publishing {
     }
 }
 
-signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["mavenJava"])
-}
+//signing {
+//    val signingKey: String? by project
+//    val signingPassword: String? by project
+//    useInMemoryPgpKeys(signingKey, signingPassword)
+//    sign(publishing.publications["mavenJava"])
+//}
 
 tasks.javadoc {
     val doclet = options as StandardJavadocDocletOptions

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/MongoCatalogTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/MongoCatalogTest.java
@@ -177,13 +177,14 @@ public class MongoCatalogTest extends MongoSparkConnectorTestCase {
   void dropNamespaceTest() {
     Identifier identifier = createIdentifier(DATABASE_NAME, COLLECTION_NAME);
     assertThrows(
-        IllegalStateException.class, () -> MONGO_CATALOG.dropNamespace(identifier.namespace()));
+        IllegalStateException.class,
+        () -> MONGO_CATALOG.dropNamespace(identifier.namespace(), true));
 
     MONGO_CATALOG.initialize(identifier.namespace()[0], getConnectionProviderOptions());
-    assertFalse(MONGO_CATALOG.dropNamespace(identifier.namespace()));
+    assertFalse(MONGO_CATALOG.dropNamespace(identifier.namespace(), true));
 
     createCollection(identifier);
-    assertTrue(MONGO_CATALOG.dropNamespace(identifier.namespace()));
+    assertTrue(MONGO_CATALOG.dropNamespace(identifier.namespace(), true));
   }
 
   @Test

--- a/src/main/java/com/mongodb/spark/sql/connector/MongoCatalog.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/MongoCatalog.java
@@ -185,7 +185,7 @@ public class MongoCatalog implements TableCatalog, SupportsNamespaces {
    * @return true if the namespace (database) was dropped
    */
   @Override
-  public boolean dropNamespace(final String[] namespace) {
+  public boolean dropNamespace(final String[] namespace, final boolean cascade) {
     assertInitialized();
     if (namespaceExists(namespace)) {
       MongoConfig.writeConfig(options)

--- a/src/main/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactory.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactory.java
@@ -58,13 +58,12 @@ public final class DefaultMongoClientFactory implements MongoClientFactory {
       return false;
     }
     final DefaultMongoClientFactory that = (DefaultMongoClientFactory) o;
-    return config.equals(that.config)
-        && Objects.equals(mongoDriverInformation, that.mongoDriverInformation);
+    return config.equals(that.config);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(config, mongoDriverInformation);
+    return Objects.hash(config);
   }
 
   private static MongoDriverInformation generateMongoDriverInformation(final String configType) {

--- a/src/main/java/com/mongodb/spark/sql/connector/connection/MongoClientCache.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/connection/MongoClientCache.java
@@ -29,6 +29,7 @@ import com.mongodb.spark.sql.connector.annotations.ThreadSafe;
 import com.mongodb.spark.sql.connector.assertions.Assertions;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -46,7 +47,7 @@ import org.jetbrains.annotations.VisibleForTesting;
  */
 @ThreadSafe
 final class MongoClientCache {
-  private final HashMap<MongoClientFactory, CachedMongoClient> cache = new HashMap<>();
+  private final Map<MongoClientFactory, CachedMongoClient> cache = new HashMap<>();
   private final long keepAliveNanos;
   private final long initialCleanUpDelayMS;
   private final long cleanUpDelayMS;
@@ -92,7 +93,7 @@ final class MongoClientCache {
     return cache
         .computeIfAbsent(
             mongoClientFactory,
-            (factory) -> new CachedMongoClient(this, factory.create(), keepAliveNanos))
+            factory -> new CachedMongoClient(this, factory.create(), keepAliveNanos))
         .acquire();
   }
 

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/InternalRowToRowFunction.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/InternalRowToRowFunction.java
@@ -18,15 +18,18 @@
 package com.mongodb.spark.sql.connector.schema;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer$;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder$;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.types.StructType;
-import scala.collection.immutable.Seq;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
 
 /**
  * An InternalRow to Row function that uses a resolved and bound encoder for the given schema.
@@ -39,11 +42,12 @@ final class InternalRowToRowFunction implements Function<InternalRow, Row>, Seri
 
   private final ExpressionEncoder.Deserializer<Row> deserializer;
 
-  @SuppressWarnings("unchecked")
   InternalRowToRowFunction(final StructType schema) {
-    ExpressionEncoder<Row> rowEncoder = RowEncoder$.MODULE$.apply(schema);
-    Seq<Attribute> attributeSeq =
-        (Seq<Attribute>) (Seq<? extends Attribute>) rowEncoder.schema().toAttributes();
+    List<Attribute> attributesList = Arrays.stream(schema.fields())
+        .map(new StructFieldToAttributeFunction())
+        .collect(Collectors.toList());
+    Seq<Attribute> attributeSeq = JavaConverters.asScalaBuffer(attributesList).toSeq();
+    ExpressionEncoder<Row> rowEncoder = ExpressionEncoder.apply(schema);
     this.deserializer =
         rowEncoder.resolveAndBind(attributeSeq, SimpleAnalyzer$.MODULE$).createDeserializer();
   }

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/StructFieldToAttributeFunction.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/StructFieldToAttributeFunction.java
@@ -1,0 +1,24 @@
+package com.mongodb.spark.sql.connector.schema;
+
+import java.util.Collections;
+import java.util.function.Function;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.ExprId;
+import org.apache.spark.sql.catalyst.expressions.ExprId$;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.types.StructField;
+import scala.collection.JavaConverters;
+
+class StructFieldToAttributeFunction implements Function<StructField, AttributeReference> {
+  @Override
+  public AttributeReference apply(final StructField field) {
+    ExprId exprId = NamedExpression.newExprId();
+    return new AttributeReference(
+        field.name(),
+        field.dataType(),
+        field.nullable(),
+        field.metadata(),
+        ExprId$.MODULE$.apply(exprId.id()),
+        JavaConverters.asScalaBuffer(Collections.emptyList()));
+  }
+}

--- a/src/test/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactoryTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactoryTest.java
@@ -1,0 +1,53 @@
+package com.mongodb.spark.sql.connector.connection;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.internal.MongoClientImpl;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.spark.sql.connector.config.MongoConfig.CONNECTION_STRING_CONFIG;
+import static com.mongodb.spark.sql.connector.config.MongoConfig.DATABASE_NAME_CONFIG;
+import static com.mongodb.spark.sql.connector.config.MongoConfig.PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class DefaultMongoClientFactoryTest {
+
+    private static final Map<String, String> CONFIG_MAP = new HashMap<>();
+
+    static {
+        CONFIG_MAP.put(PREFIX + CONNECTION_STRING_CONFIG, "mongodb://localhost:27017");
+        CONFIG_MAP.put(PREFIX + DATABASE_NAME_CONFIG, "db");
+    }
+
+    @Test
+    void factoriesWithSameConfigCreateClientsWithEqualSettings() {
+        MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config);
+
+        MongoClient client1 = factory1.create();
+        MongoClient client2 = factory2.create();
+
+        assertInstanceOf(MongoClientImpl.class, client1);
+        assertInstanceOf(MongoClientImpl.class, client2);
+        assertEquals(
+                ((MongoClientImpl) client1).getSettings(), ((MongoClientImpl) client2).getSettings());
+    }
+
+    @Test
+    void factoriesWithSameConfigCreateNotSameClients() {
+        MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config);
+
+        MongoClient client1 = factory1.create();
+        MongoClient client2 = factory2.create();
+
+        assertNotSame(client1, client2);
+    }
+}

--- a/src/test/java/com/mongodb/spark/sql/connector/connection/MongoClientCacheTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/connection/MongoClientCacheTest.java
@@ -18,27 +18,39 @@
 package com.mongodb.spark.sql.connector.connection;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.client.MongoClient;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-public class MongoClientCacheTest {
+import java.util.HashMap;
+import java.util.Map;
 
+@ExtendWith(MockitoExtension.class)
+class MongoClientCacheTest {
+  private static final Map<String, String> CONFIG_MAP = new HashMap<>();
   @Mock
   private MongoClientFactory mongoClientFactory;
 
   @Mock
   private MongoClient mongoClient;
 
+    static {
+        CONFIG_MAP.put(
+                MongoConfig.PREFIX + MongoConfig.CONNECTION_STRING_CONFIG, "mongodb://localhost:27017");
+        CONFIG_MAP.put(MongoConfig.PREFIX + MongoConfig.DATABASE_NAME_CONFIG, "db");
+    }
+
   @Test
-  void testNormalUsecase() {
+  void testNormalUseCase() {
     MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
     when(mongoClientFactory.create()).thenReturn(mongoClient);
 
@@ -55,6 +67,75 @@ public class MongoClientCacheTest {
     sleep(200);
     verify(mongoClient, times(1)).close();
   }
+
+    @Test
+    void factoriesWithSameConfigCreateSameClientsThroughCache() {
+        MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualConfigCreateNotSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.createConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertNotSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualReadConfigsCreateSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.readConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.readConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualWriteConfigsCreateNotSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.writeConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.writeConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualReadWriteConfigsCreateNotSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.readConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.writeConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertNotSame(client1, client2);
+    }
 
   @Test
   void testKeepAliveReuseOfClient() {


### PR DESCRIPTION
MongoDriverInformation does not implement hashCode/equals which effectively prevents DefaultMongoClientFactory from being used as a key in MongoClientCache i.e. even for the same configuration factories are never equal and create multiple, redundant cache entries.