### PR TITLE
Fix MongoClientCache for factories with same/equal configurations

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactory.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactory.java
@@ -58,13 +58,12 @@ public final class DefaultMongoClientFactory implements MongoClientFactory {
       return false;
     }
     final DefaultMongoClientFactory that = (DefaultMongoClientFactory) o;
-    return config.equals(that.config)
-        && Objects.equals(mongoDriverInformation, that.mongoDriverInformation);
+    return config.equals(that.config);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(config, mongoDriverInformation);
+    return Objects.hash(config);
   }
 
   private static MongoDriverInformation generateMongoDriverInformation(final String configType) {

--- a/src/main/java/com/mongodb/spark/sql/connector/connection/MongoClientCache.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/connection/MongoClientCache.java
@@ -29,6 +29,7 @@ import com.mongodb.spark.sql.connector.annotations.ThreadSafe;
 import com.mongodb.spark.sql.connector.assertions.Assertions;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -46,7 +47,7 @@ import org.jetbrains.annotations.VisibleForTesting;
  */
 @ThreadSafe
 final class MongoClientCache {
-  private final HashMap<MongoClientFactory, CachedMongoClient> cache = new HashMap<>();
+  private final Map<MongoClientFactory, CachedMongoClient> cache = new HashMap<>();
   private final long keepAliveNanos;
   private final long initialCleanUpDelayMS;
   private final long cleanUpDelayMS;
@@ -92,7 +93,7 @@ final class MongoClientCache {
     return cache
         .computeIfAbsent(
             mongoClientFactory,
-            (factory) -> new CachedMongoClient(this, factory.create(), keepAliveNanos))
+            factory -> new CachedMongoClient(this, factory.create(), keepAliveNanos))
         .acquire();
   }
 

--- a/src/test/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactoryTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactoryTest.java
@@ -1,0 +1,53 @@
+package com.mongodb.spark.sql.connector.connection;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.internal.MongoClientImpl;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.spark.sql.connector.config.MongoConfig.CONNECTION_STRING_CONFIG;
+import static com.mongodb.spark.sql.connector.config.MongoConfig.DATABASE_NAME_CONFIG;
+import static com.mongodb.spark.sql.connector.config.MongoConfig.PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class DefaultMongoClientFactoryTest {
+
+    private static final Map<String, String> CONFIG_MAP = new HashMap<>();
+
+    static {
+        CONFIG_MAP.put(PREFIX + CONNECTION_STRING_CONFIG, "mongodb://localhost:27017");
+        CONFIG_MAP.put(PREFIX + DATABASE_NAME_CONFIG, "db");
+    }
+
+    @Test
+    void factoriesWithSameConfigCreateClientsWithEqualSettings() {
+        MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config);
+
+        MongoClient client1 = factory1.create();
+        MongoClient client2 = factory2.create();
+
+        assertInstanceOf(MongoClientImpl.class, client1);
+        assertInstanceOf(MongoClientImpl.class, client2);
+        assertEquals(
+                ((MongoClientImpl) client1).getSettings(), ((MongoClientImpl) client2).getSettings());
+    }
+
+    @Test
+    void factoriesWithSameConfigCreateNotSameClients() {
+        MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config);
+
+        MongoClient client1 = factory1.create();
+        MongoClient client2 = factory2.create();
+
+        assertNotSame(client1, client2);
+    }
+}

--- a/src/test/java/com/mongodb/spark/sql/connector/connection/MongoClientCacheTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/connection/MongoClientCacheTest.java
@@ -18,27 +18,39 @@
 package com.mongodb.spark.sql.connector.connection;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.mongodb.client.MongoClient;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-public class MongoClientCacheTest {
+import java.util.HashMap;
+import java.util.Map;
 
+@ExtendWith(MockitoExtension.class)
+class MongoClientCacheTest {
+  private static final Map<String, String> CONFIG_MAP = new HashMap<>();
   @Mock
   private MongoClientFactory mongoClientFactory;
 
   @Mock
   private MongoClient mongoClient;
 
+    static {
+        CONFIG_MAP.put(
+                MongoConfig.PREFIX + MongoConfig.CONNECTION_STRING_CONFIG, "mongodb://localhost:27017");
+        CONFIG_MAP.put(MongoConfig.PREFIX + MongoConfig.DATABASE_NAME_CONFIG, "db");
+    }
+
   @Test
-  void testNormalUsecase() {
+  void testNormalUseCase() {
     MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
     when(mongoClientFactory.create()).thenReturn(mongoClient);
 
@@ -55,6 +67,75 @@ public class MongoClientCacheTest {
     sleep(200);
     verify(mongoClient, times(1)).close();
   }
+
+    @Test
+    void factoriesWithSameConfigCreateSameClientsThroughCache() {
+        MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualConfigCreateNotSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.createConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.createConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertNotSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualReadConfigsCreateSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.readConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.readConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualWriteConfigsCreateNotSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.writeConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.writeConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertSame(client1, client2);
+    }
+
+    @Test
+    void factoriesWithEqualReadWriteConfigsCreateNotSameClientsThroughCache() {
+        MongoConfig config1 = MongoConfig.readConfig(CONFIG_MAP);
+        MongoConfig config2 = MongoConfig.writeConfig(CONFIG_MAP);
+        DefaultMongoClientFactory factory1 = new DefaultMongoClientFactory(config1);
+        DefaultMongoClientFactory factory2 = new DefaultMongoClientFactory(config2);
+        MongoClientCache mongoClientCache = new MongoClientCache(0, 0, 100);
+
+        MongoClient client1 = mongoClientCache.acquire(factory1);
+        MongoClient client2 = mongoClientCache.acquire(factory2);
+
+        assertNotSame(client1, client2);
+    }
 
   @Test
   void testKeepAliveReuseOfClient() {


### PR DESCRIPTION
MongoDriverInformation does not implement hashCode/equals which effectively prevents DefaultMongoClientFactory from being used as a key in MongoClientCache i.e. even for the same configuration factories are never equal and create multiple, redundant cache entries.