### PR TITLE
SimpleMongoConfig does not implement hashCode/equals

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/config/SimpleMongoConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/SimpleMongoConfig.java
@@ -19,6 +19,7 @@ package com.mongodb.spark.sql.connector.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** A simple implementation of MongoConfig with no set the use case */
@@ -67,5 +68,22 @@ class SimpleMongoConfig implements MongoConfig {
         })
         .collect(Collectors.joining(", "));
     return "MongoConfig{options=" + cleanedOptions + ", usageMode=NotSet}";
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SimpleMongoConfig that = (SimpleMongoConfig) o;
+    return Objects.equals(options, that.options);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(options);
   }
 }

--- a/src/test/java/com/mongodb/spark/sql/connector/config/SimpleMongoConfigTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/config/SimpleMongoConfigTest.java
@@ -1,0 +1,35 @@
+package com.mongodb.spark.sql.connector.config;
+
+import static com.mongodb.spark.sql.connector.config.MongoConfig.CONNECTION_STRING_CONFIG;
+import static com.mongodb.spark.sql.connector.config.MongoConfig.DATABASE_NAME_CONFIG;
+import static com.mongodb.spark.sql.connector.config.MongoConfig.PREFIX;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SimpleMongoConfigTest {
+
+  private static final Map<String, String> CONFIG_MAP = new HashMap<>();
+
+  static {
+    CONFIG_MAP.put(PREFIX + CONNECTION_STRING_CONFIG, "mongodb://localhost:27017");
+    CONFIG_MAP.put(PREFIX + DATABASE_NAME_CONFIG, "db");
+  }
+
+  @Test
+  void createSimpleConfig() {
+    MongoConfig config = MongoConfig.createConfig(CONFIG_MAP);
+
+    assertInstanceOf(SimpleMongoConfig.class, config);
+  }
+
+  @Test
+  void configsCreateForSameMapAreEqual() {
+    MongoConfig config1 = MongoConfig.createConfig(CONFIG_MAP);
+    MongoConfig config2 = MongoConfig.createConfig(CONFIG_MAP);
+
+    assertEquals(config1, config2);
+  }
+}


### PR DESCRIPTION
Without equals the SimpleMongoConfigs cannot be used with DefaultMongoClientFactory as they break the equal check there.