### PR TITLE
Added Schema hints for use when inferring schemas.

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java
@@ -19,6 +19,7 @@ package com.mongodb.spark.sql.connector.schema;
 
 import static com.mongodb.assertions.Assertions.fail;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.groupingBy;
 
 import com.mongodb.client.MongoDatabase;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -67,6 +69,8 @@ import org.jetbrains.annotations.VisibleForTesting;
 public final class InferSchema {
   /** Inferred schema metadata */
   public static final Metadata INFERRED_METADATA = Metadata.fromJson("{\"inferred\": true}");
+
+  private static final StructType EMPTY_SCHEMA = new StructType();
 
   /**
    * Infer the schema for the specified configuration.
@@ -147,7 +151,57 @@ public final class InferSchema {
   @NotNull
   private static StructType getStructType(
       final BsonDocument bsonDocument, final ReadConfig readConfig) {
-    return (StructType) getDataType(bsonDocument, readConfig);
+    Map<String, StructField> fieldMap = new HashMap<>();
+    bsonDocument.forEach((k, v) -> {
+      fieldMap.put(k, new StructField(k, getDataType(v, readConfig), true, INFERRED_METADATA));
+    });
+
+    for (StructField f : readConfig.getSchemaHints().fields()) {
+
+      String[] fieldNameParts = f.name().split("\\.");
+      String topLevelFieldName = fieldNameParts[0];
+
+      // Create the hinted StructField
+      // Works through the fieldNameParts in reverse and builds up to the top level field.
+      StructField schemaHintField = null;
+      for (int i = fieldNameParts.length - 1; i >= 0; i--) {
+        String fieldName = fieldNameParts[i];
+        if (schemaHintField == null) {
+          schemaHintField =
+              new StructField(fieldName, f.dataType(), f.nullable(), INFERRED_METADATA);
+        } else {
+          schemaHintField = new StructField(
+              fieldName,
+              DataTypes.createStructType(singletonList(schemaHintField)),
+              true,
+              INFERRED_METADATA);
+        }
+      }
+
+      // Merge datatypes if one already exists
+      if (fieldMap.containsKey(topLevelFieldName)) {
+        StructField inferredStructField = fieldMap.get(topLevelFieldName);
+        DataType mergedDataType =
+            rhsPreferredMerge(inferredStructField.dataType(), schemaHintField.dataType());
+
+        fieldMap.put(
+            fieldNameParts[0],
+            new StructField(
+                inferredStructField.name(),
+                mergedDataType,
+                inferredStructField.nullable(),
+                inferredStructField.metadata()));
+      } else {
+        fieldMap.put(topLevelFieldName, schemaHintField);
+      }
+    }
+
+    List<StructField> structFields = fieldMap.values().stream()
+        .sorted(Comparator.comparing(StructField::name))
+        .collect(Collectors.toList());
+
+    return (StructType)
+        dataTypeCheckStructTypeToMapType(DataTypes.createStructType(structFields), readConfig);
   }
 
   @VisibleForTesting
@@ -390,6 +444,52 @@ public final class InferSchema {
       }
     }
     return dataType;
+  }
+
+  /**
+   * Recursive merge that prefers the rhs datatype value over the lhs. For use with partial schema hints.
+   *
+   * @param lhs the left hand side datatype
+   * @param rhs the right hand side datatype
+   * @return the merged original and preferred data type
+   */
+  @VisibleForTesting
+  static DataType rhsPreferredMerge(final DataType lhs, final DataType rhs) {
+
+    // If they are both structs process the fields and merge.
+    if (lhs instanceof StructType && rhs instanceof StructType) {
+      Map<String, StructField> lhsMap = Arrays.stream(((StructType) lhs).fields())
+          .collect(Collectors.toMap(StructField::name, f -> f));
+      Map<String, StructField> rhsMap = Arrays.stream(((StructType) rhs).fields())
+          .collect(Collectors.toMap(StructField::name, f -> f));
+
+      Map<String, StructField> newFields = new HashMap<>();
+
+      lhsMap.forEach((k, v) -> {
+        if (rhsMap.containsKey(k)) {
+          newFields.put(
+              k,
+              new StructField(
+                  v.name(),
+                  rhsPreferredMerge(v.dataType(), rhsMap.get(k).dataType()),
+                  v.nullable(),
+                  v.metadata()));
+        } else {
+          newFields.put(k, v);
+        }
+      });
+
+      rhsMap.forEach((k, v) -> {
+        if (!newFields.containsKey(k)) {
+          newFields.put(k, v);
+        }
+      });
+
+      return new StructType(newFields.values().toArray(new StructField[0]));
+    }
+
+    // Otherwise RHS wins.
+    return rhs;
   }
 
   private static final StructType PLACE_HOLDER_STRUCT_TYPE =

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/InferSchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/InferSchemaTest.java
@@ -610,7 +610,7 @@ public class InferSchemaTest extends SchemaTest {
   }
 
   @Test
-  public void rhsPreferredMergeTest() {
+  void rhsPreferredMergeTest() {
     // Can handle simple merges
     DataType lhs = DataType.fromDDL("a LONG");
     DataType rhs = DataType.fromDDL("b LONG");


### PR DESCRIPTION
Added a new configuration: `schemaHints`.
Users can now supply schema to enforce the schema information about known field types when inferring schema.

Supports the following Spark formats:
  - DDL: `value STRING,count INT`
  - SQL DDL: `STRUCT<value: STRING, count: INT>`
  - Simple String DDL: `struct<value:string,count:int>`
  - JSON: ```{"type":"struct","fields":[ {"name":"value","type":"string","nullable":true}, {"name":"count","type":"integer","nullable":true}]}```

To create DDL or Json schema strings simply use the Spark shell:

```
import org.apache.spark.sql.types._
val mySchema = StructType(Seq(StructField("value", StringType), StructField("count", IntegerType)))

mySchema.toDDL
mySchema.sql
mySchema.simpleString
mySchema.json
```

Or in PySpark:

```
from pyspark.sql.types import StructType, StructField, StringType, IntegerType
mySchema = StructType([ StructField('value',  StringType(), True), StructField('count', IntegerType(), True)])

mySchema.simpleString()
mySchema.json()
```

SPARK-365