### PR TITLE
Added parse mode support when reading data from MongoDB.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,8 +95,6 @@ dependencies {
     testImplementation("org.apache.spark:spark-catalyst_$scalaVersion:$sparkVersion")
     testImplementation("org.apache.spark:spark-streaming_$scalaVersion:$sparkVersion")
 
-    testCompileOnly("org.jetbrains:annotations:${project.extra["annotationsVersion"]}")
-
     // Unit Tests
     testImplementation(platform("org.junit:junit-bom:5.8.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
@@ -105,6 +103,7 @@ dependencies {
 
     // Integration Tests
     testImplementation("org.apache.commons:commons-lang3:${project.extra["commons-lang3"]}")
+    testImplementation("org.jetbrains:annotations:${project.extra["annotationsVersion"]}")
 }
 
 val defaultJdkVersion: Int = 11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,8 @@ dependencies {
     testImplementation("org.apache.spark:spark-catalyst_$scalaVersion:$sparkVersion")
     testImplementation("org.apache.spark:spark-streaming_$scalaVersion:$sparkVersion")
 
+    testCompileOnly("org.jetbrains:annotations:${project.extra["annotationsVersion"]}")
+
     // Unit Tests
     testImplementation(platform("org.junit:junit-bom:5.8.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoBatchTest.java
@@ -18,6 +18,7 @@ package com.mongodb.spark.sql.connector.read;
 
 import static com.mongodb.spark.sql.connector.config.MongoConfig.COMMENT_CONFIG;
 import static com.mongodb.spark.sql.connector.interop.JavaScala.asJava;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.apache.spark.sql.types.DataTypes.createStructField;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -41,6 +43,7 @@ import com.mongodb.spark.sql.connector.schema.RowToBsonDocumentConverter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.spark.SparkException;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.DataFrameReader;
@@ -49,6 +52,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.bson.BsonDocument;
@@ -653,6 +657,7 @@ class MongoBatchTest extends MongoSparkConnectorTestCase {
 
     List<BsonDocument> collectionData =
         toBsonDocuments(spark.read().textFile(READ_RESOURCES_HOBBITS_JSON_PATH));
+    getCollection().drop();
     getCollection().insertMany(collectionData);
 
     ReadConfig readConfig = MongoConfig.readConfig(asJava(spark.initialSessionOptions()))
@@ -675,6 +680,70 @@ class MongoBatchTest extends MongoSparkConnectorTestCase {
                   .toJSON()));
         },
         readConfig);
+  }
+
+  @Test
+  void testReadsWithParseMode() {
+    SparkSession spark = getOrCreateSparkSession();
+
+    List<BsonDocument> collectionData = asList(
+        BsonDocument.parse("{_id: 1, name: 'Ada Lovelace', address: {street: 'St James Square'}}"),
+        BsonDocument.parse(
+            "{_id: 2, name: 'Charles Babbage', address: {street: '5 Devonshire Street'}}"),
+        BsonDocument.parse(
+            "{_id: 3, name: 'Alan Turing', address: '{\"street\": \"Bletchley Hall\"}'}"),
+        BsonDocument.parse("{_id: 4, name: 'Timothy Berners-Lee', address: {}}"));
+    getCollection().insertMany(collectionData);
+
+    StructType schema = createStructType(asList(
+        createStructField("_id", DataTypes.IntegerType, false),
+        createStructField("name", DataTypes.StringType, true),
+        createStructField("address", DataType.fromDDL("street STRING"), true)));
+
+    DataFrameReader errorDFR = spark.read().format("mongodb").schema(schema);
+    assertThrows(SparkException.class, () -> errorDFR.load().toJSON().collect());
+    assertThrows(SparkException.class, () -> errorDFR
+        .option(ReadConfig.PARSE_MODE, ReadConfig.ParseMode.FAILFAST.name())
+        .load()
+        .toJSON()
+        .collect());
+
+    DataFrameReader dfr = spark.read().format("mongodb").schema(schema);
+    List<BsonDocument> expectedData =
+        collectionData.stream().map(BsonDocument::clone).collect(Collectors.toList());
+    expectedData.remove(2);
+    assertEquals(
+        expectedData,
+        toBsonDocuments(dfr.option(ReadConfig.PARSE_MODE, ReadConfig.ParseMode.DROPMALFORMED.name())
+            .load()
+            .toJSON()));
+
+    // Note toJSON uses the default ignoreNullFields = true
+    dfr = dfr.option(ReadConfig.PARSE_MODE, ReadConfig.ParseMode.PERMISSIVE.name());
+    expectedData = collectionData.stream().map(BsonDocument::clone).collect(Collectors.toList());
+    expectedData.remove(2);
+    expectedData.add(2, BsonDocument.parse("{_id: 3, name: 'Alan Turing'}"));
+    assertEquals(expectedData, toBsonDocuments(dfr.load().toJSON()));
+
+    // No corrupted field in the schema - so ignore
+    String corruptedField = "_corrupted";
+    dfr = dfr.option(ReadConfig.COLUMN_NAME_OF_CORRUPT_RECORD, corruptedField);
+    assertEquals(expectedData, toBsonDocuments(dfr.load().toJSON()));
+
+    // With corrupted field
+    StructType schemaWithCorruptedField = schema.add(corruptedField, DataTypes.StringType);
+    dfr = dfr.schema(schemaWithCorruptedField);
+    expectedData = collectionData.stream().map(BsonDocument::clone).collect(Collectors.toList());
+
+    expectedData.remove(2);
+    expectedData.add(
+        2,
+        BsonDocument.parse(
+            format(
+                "{_id: 3, name: 'Alan Turing', _corrupted: '%s'}",
+                "{\"_id\": 3, \"name\": \"Alan Turing\", \"address\": \"{\\\\\"street\\\\\": \\\\\"Bletchley Hall\\\\\"}\"}")));
+
+    assertEquals(expectedData, toBsonDocuments(dfr.load().toJSON()));
   }
 
   private List<BsonDocument> toBsonDocuments(final Dataset<String> dataset) {

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -191,7 +191,8 @@ public final class ReadConfig extends AbstractMongoConfig {
    * Parsing strategy for handling corrupt records during reads.
    *
    * <ul>
-   *   <li>{@code PERMISSIVE}: When it meets a corrupted record, sets any malformed fields to null.
+   *   <li>{@code PERMISSIVE}: When it meets a corrupted record, sets any malformed fields or missing fields to null.
+   *   Note, the data schema is forced to be fully nullable, so may be different from the one provided.
    *   Configure the {@value COLUMN_NAME_OF_CORRUPT_RECORD} if you want to store the whole record
    *   as an extended json string when encountering a corrupt record.
    *   When inferring a schema, it will implicitly add a {@value COLUMN_NAME_OF_CORRUPT_RECORD} field

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -179,9 +179,7 @@ public final class ReadConfig extends AbstractMongoConfig {
     DROPMALFORMED;
 
     static ParseMode fromString(final String userParseMode) {
-     validateConfig(userParseMode, Objects::nonNull, () -> "The userParseMode can't be null");
       try {
-      
         return ParseMode.valueOf(userParseMode.toUpperCase());
       } catch (IllegalArgumentException e) {
         throw new ConfigException(format("'%s' is not a valid Parse mode", userParseMode));

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -179,7 +179,9 @@ public final class ReadConfig extends AbstractMongoConfig {
     DROPMALFORMED;
 
     static ParseMode fromString(final String userParseMode) {
+     validateConfig(userParseMode, Objects::nonNull, () -> "The userParseMode can't be null");
       try {
+      
         return ParseMode.valueOf(userParseMode.toUpperCase());
       } catch (IllegalArgumentException e) {
         throw new ConfigException(format("'%s' is not a valid Parse mode", userParseMode));

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoBatch.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoBatch.java
@@ -43,8 +43,7 @@ final class MongoBatch implements Batch {
   MongoBatch(final StructType schema, final ReadConfig readConfig) {
     this.schema = schema;
     this.readConfig = readConfig;
-    this.bsonDocumentToRowConverter =
-        new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
+    this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema, readConfig);
   }
 
   /** Returns a list of partitions that split the collection into parts */

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoContinuousStream.java
@@ -70,8 +70,7 @@ final class MongoContinuousStream implements ContinuousStream {
         checkpointLocation,
         MongoOffset.getInitialOffset(readConfig));
     this.readConfig = readConfig;
-    this.bsonDocumentToRowConverter =
-        new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
+    this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema, readConfig);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
@@ -73,8 +73,7 @@ final class MongoMicroBatchStream implements MicroBatchStream {
         checkpointLocation,
         MongoOffset.getInitialOffset(readConfig));
     this.readConfig = readConfig;
-    this.bsonDocumentToRowConverter =
-        new BsonDocumentToRowConverter(schema, readConfig.outputExtendedJson());
+    this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema, readConfig);
   }
 
   @Override

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/BsonDocumentToRowConverter.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/BsonDocumentToRowConverter.java
@@ -243,7 +243,7 @@ public final class BsonDocumentToRowConverter implements Serializable {
         .forEach((k, v) ->
             map.put(k, convertBsonValue(createFieldPath(fieldName, k), dataType.valueType(), v)));
 
-    return scala.collection.immutable.Map$.MODULE$.from(JavaScala.asScala(map));
+    return JavaScala.asScalaImmutable(map);
   }
 
   private Object[] convertToArray(

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/ConverterHelper.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/ConverterHelper.java
@@ -35,20 +35,25 @@ public final class ConverterHelper {
       new SchemaToExpressionEncoderFunction();
   static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
 
-  static final JsonWriterSettings RELAXED_JSON_WRITER_SETTINGS = JsonWriterSettings.builder()
-      .outputMode(JsonMode.RELAXED)
-      .binaryConverter((value, writer) ->
-          writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
-      .dateTimeConverter((value, writer) -> {
-        ZonedDateTime zonedDateTime = Instant.ofEpochMilli(value).atZone(ZoneOffset.UTC);
-        writer.writeString(DateTimeFormatter.ISO_DATE_TIME.format(zonedDateTime));
-      })
-      .decimal128Converter((value, writer) -> writer.writeString(value.toString()))
-      .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
-      .symbolConverter((value, writer) -> writer.writeString(value))
-      .build();
+  static JsonWriterSettings getJsonWriterSettings(final boolean outputExtendedJson) {
+    return outputExtendedJson ? EXTENDED_JSON_WRITER_SETTINGS : RELAXED_JSON_WRITER_SETTINGS;
+  }
 
-  static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
+  private static final JsonWriterSettings RELAXED_JSON_WRITER_SETTINGS =
+      JsonWriterSettings.builder()
+          .outputMode(JsonMode.RELAXED)
+          .binaryConverter((value, writer) ->
+              writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
+          .dateTimeConverter((value, writer) -> {
+            ZonedDateTime zonedDateTime = Instant.ofEpochMilli(value).atZone(ZoneOffset.UTC);
+            writer.writeString(DateTimeFormatter.ISO_DATE_TIME.format(zonedDateTime));
+          })
+          .decimal128Converter((value, writer) -> writer.writeString(value.toString()))
+          .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
+          .symbolConverter((value, writer) -> writer.writeString(value))
+          .build();
+
+  private static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
       JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/schema/InferSchema.java
@@ -121,7 +121,15 @@ public final class InferSchema {
     StructType structType = bsonDocuments.stream()
         .map(d -> getStructType(d, readConfig))
         .reduce(PLACE_HOLDER_STRUCT_TYPE, (dt1, dt2) -> compatibleStructType(dt1, dt2, readConfig));
-    return (StructType) removePlaceholders(structType);
+
+    structType = (StructType) removePlaceholders(structType);
+
+    String corruptDocumentColumnName = readConfig.getColumnNameOfCorruptRecord();
+    if (!corruptDocumentColumnName.isEmpty()) {
+      structType = structType.add(DataTypes.createStructField(
+          corruptDocumentColumnName, DataTypes.StringType, true, INFERRED_METADATA));
+    }
+    return structType;
   }
 
   private static DataType removePlaceholders(final DataType dataType) {

--- a/src/main/java_scala_212/com/mongodb/spark/sql/connector/interop/JavaScala.java
+++ b/src/main/java_scala_212/com/mongodb/spark/sql/connector/interop/JavaScala.java
@@ -19,7 +19,10 @@ package com.mongodb.spark.sql.connector.interop;
 
 import java.util.List;
 import java.util.Map;
+import scala.Tuple2;
 import scala.collection.JavaConverters;
+import scala.collection.immutable.Map$;
+import scala.collection.mutable.Builder;
 
 /** Utils object to convert Java To Scala to enable cross build */
 @SuppressWarnings("deprecated")
@@ -36,6 +39,23 @@ public final class JavaScala {
    */
   public static <K, V> scala.collection.Map<K, V> asScala(final Map<K, V> data) {
     return JavaConverters.mapAsScalaMap(data);
+  }
+
+  /**
+   * Wrapper to convert a java map to an immutable scala map
+   *
+   * @param data java collection
+   * @param <K> key
+   * @param <V> value
+   * @return scala collection
+   */
+  public static <K, V> scala.collection.immutable.Map<K, V> asScalaImmutable(final Map<K, V> data) {
+    Builder<Tuple2<K, V>, scala.collection.immutable.Map<K, V>> mapBuilder =
+        Map$.MODULE$.newBuilder();
+    for (Map.Entry<K, V> entry : data.entrySet()) {
+      mapBuilder.$plus$eq(new Tuple2<>(entry.getKey(), entry.getValue()));
+    }
+    return mapBuilder.result();
   }
 
   /**

--- a/src/main/java_scala_213/com/mongodb/spark/sql/connector/interop/JavaScala.java
+++ b/src/main/java_scala_213/com/mongodb/spark/sql/connector/interop/JavaScala.java
@@ -37,17 +37,17 @@ public final class JavaScala {
     return CollectionConverters.MapHasAsScala(data).asScala();
   }
 
-    /**
-     * Wrapper to convert a java map to an immutable scala map
-     *
-     * @param data java collection
-     * @param <K> key
-     * @param <V> value
-     * @return scala collection
-     */
-    public static <K, V> scala.collection.immutable.Map<K, V> asScalaImmutable(final Map<K, V> data) {
-        return scala.collection.immutable.Map.from(asScala(data));
-    }
+  /**
+   * Wrapper to convert a java map to an immutable scala map
+   *
+   * @param data java collection
+   * @param <K> key
+   * @param <V> value
+   * @return scala collection
+   */
+  public static <K, V> scala.collection.immutable.Map<K, V> asScalaImmutable(final Map<K, V> data) {
+    return scala.collection.immutable.Map.from(asScala(data));
+  }
 
   /**
    * Wrapper to convert a java list to a scala seq

--- a/src/main/java_scala_213/com/mongodb/spark/sql/connector/interop/JavaScala.java
+++ b/src/main/java_scala_213/com/mongodb/spark/sql/connector/interop/JavaScala.java
@@ -37,6 +37,18 @@ public final class JavaScala {
     return CollectionConverters.MapHasAsScala(data).asScala();
   }
 
+    /**
+     * Wrapper to convert a java map to an immutable scala map
+     *
+     * @param data java collection
+     * @param <K> key
+     * @param <V> value
+     * @return scala collection
+     */
+    public static <K, V> scala.collection.immutable.Map<K, V> asScalaImmutable(final Map<K, V> data) {
+        return scala.collection.immutable.Map.from(asScala(data));
+    }
+
   /**
    * Wrapper to convert a java list to a scala seq
    *

--- a/src/test/java/com/mongodb/spark/sql/connector/config/MongoConfigTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/config/MongoConfigTest.java
@@ -304,6 +304,28 @@ public class MongoConfigTest {
     assertFalse(mongoConfig.toWriteConfig().toString().contains("mongodb://"));
   }
 
+  @Test
+  void testReadConfigMode() {
+    ReadConfig readConfig = MongoConfig.readConfig(CONFIG_MAP);
+    assertFalse(readConfig.isPermissive());
+    assertFalse(readConfig.dropMalformed());
+
+    readConfig = readConfig.withOption(ReadConfig.PARSE_MODE, "FAILFAST");
+    assertFalse(readConfig.isPermissive());
+    assertFalse(readConfig.dropMalformed());
+
+    readConfig = readConfig.withOption(ReadConfig.PARSE_MODE, "PERMISSIVE");
+    assertTrue(readConfig.isPermissive());
+    assertFalse(readConfig.dropMalformed());
+
+    readConfig = readConfig.withOption(ReadConfig.PARSE_MODE, "DROPMALFORMED");
+    assertFalse(readConfig.isPermissive());
+    assertTrue(readConfig.dropMalformed());
+
+    assertThrows(ConfigException.class, () -> MongoConfig.readConfig(CONFIG_MAP)
+        .withOption(ReadConfig.PARSE_MODE, "UNKNOWN"));
+  }
+
   @ParameterizedTest
   @MethodSource("optionsMapConfigs")
   void testErrorScenarios(final MongoConfig mongoConfig) {

--- a/src/test/java/com/mongodb/spark/sql/connector/schema/InferSchemaTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/schema/InferSchemaTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.mongodb.spark.sql.connector.config.MongoConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Stream;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -510,6 +511,32 @@ public class InferSchemaTest extends SchemaTest {
         InferSchema.inferSchema(
             singletonList(BsonDocument.parse("{mapField: {a: 1, b: 2, c: 3, d: 4}}")),
             disabledInferSchemaReadConfig));
+  }
+
+  @Test
+  @DisplayName("It inclusion of column name of corrupt record")
+  void testColumnNameOfCorruptRecord() {
+    List<BsonDocument> docs = asList(
+        BsonDocument.parse("{a: -1}"), BsonDocument.parse("{a: 1}"), BsonDocument.parse("{a: 0}"));
+    StructType structType =
+        createStructType(singletonList(createStructField("a", DataTypes.IntegerType)));
+
+    ReadConfig readConfig = READ_CONFIG;
+    assertEquals(structType, InferSchema.inferSchema(docs, READ_CONFIG));
+
+    readConfig = readConfig.withOption(ReadConfig.PARSE_MODE, "FAILFAST");
+    assertEquals(structType, InferSchema.inferSchema(docs, readConfig));
+
+    readConfig = readConfig.withOption(ReadConfig.PARSE_MODE, "DROPMALFORMED");
+    assertEquals(structType, InferSchema.inferSchema(docs, readConfig));
+
+    readConfig = readConfig.withOption(ReadConfig.PARSE_MODE, "PERMISSIVE");
+    assertEquals(structType, InferSchema.inferSchema(docs, readConfig));
+
+    readConfig = readConfig.withOption(ReadConfig.COLUMN_NAME_OF_CORRUPT_RECORD, "_corrupted");
+    structType = structType.add(createStructField("_corrupted", DataTypes.StringType));
+
+    assertEquals(structType, InferSchema.inferSchema(docs, readConfig));
   }
 
   static Stream<String> documentFieldNames() {


### PR DESCRIPTION
Adds the `mode` configuration allowing for different parsing strategies when handling documents that don't match the expected schema during reads.

The options are:

  - `FAILFAST` (default) throw an exception when parsing a document that doesn't match the schema.
  - `PERMISSIVE` Sets any invalid fields to `null`. Combine with the `columnNameOfCorruptRecord` configuration if you want to store any invalid documents as an extended json string.
  - `DROPMALFORMED` ignores the whole document.

Adds the `columnNameOfCorruptRecord` configuration whic extends the `PERMISSIVE` mode. When configured it saves the whole invalid document as extended json in that column, as long as its defined in the Schema. Inferred schemas will add the `columnNameOfCorruptRecord` column if set and the `mode` is `PERMISSIVE`.

Note: Names derive from existing spark json configurations, from where this feature takes inspiration.

SPARK-327