### PR TITLE
Auto Bucket Partitioner

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorHelper.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorHelper.java
@@ -58,7 +58,8 @@ public class MongoSparkConnectorHelper
   public static final String URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
   public static final String DEFAULT_DATABASE_NAME = "MongoSparkConnectorTest";
   public static final String DEFAULT_COLLECTION_NAME = "coll";
-  private static final String SAMPLE_DATA_TEMPLATE = "{_id: '%s', pk: '%s', dups: '%s', s: '%s'}";
+  private static final String SAMPLE_DATA_TEMPLATE =
+      "{_id: '%s', pk: '%s', dups: '%s', i: %d, s: '%s'}";
   private static final String COMPLEX_SAMPLE_DATA_TEMPLATE =
       "{_id: '%s', nested: {pk: '%s', dups: '%s', i: %d}, s: '%s'}";
 
@@ -196,13 +197,33 @@ public class MongoSparkConnectorHelper
    */
   public void loadSampleData(
       final int numberOfDocuments, final int sizeInMB, final MongoConfig config) {
+    loadSampleData(numberOfDocuments, sizeInMB, config, SAMPLE_DATA_TEMPLATE);
+  }
+
+  /**
+   * Creates complex sample data
+   *
+   * @param numberOfDocuments the total number of documents to create
+   * @param sizeInMB the total size of the documents
+   * @param config the config used for the database and collection
+   */
+  public void loadComplexSampleData(
+      final int numberOfDocuments, final int sizeInMB, final MongoConfig config) {
+    loadSampleData(numberOfDocuments, sizeInMB, config, COMPLEX_SAMPLE_DATA_TEMPLATE);
+  }
+
+  private void loadSampleData(
+      final int numberOfDocuments,
+      final int sizeInMB,
+      final MongoConfig config,
+      final String template) {
     if (!isOnline()) {
       return;
     }
     int sizeBytes = sizeInMB * 1000 * 1000;
     int totalDocumentSize = sizeBytes / numberOfDocuments;
     int sampleDataWithEmptySampleStringSize = RawBsonDocument.parse(
-            format(SAMPLE_DATA_TEMPLATE, "00000", "_10000", "00000", ""))
+            format(template, "00000", "_10000", "00000", 1, ""))
         .getByteBuffer()
         .limit();
     String sampleString =
@@ -215,44 +236,7 @@ public class MongoSparkConnectorHelper
           String pkString = format("_%s", i + 10000);
           String dupsString = StringUtils.leftPad(format("%s", i % 3 == 0 ? 0 : i), 5, "0");
           return RawBsonDocument.parse(
-              format(SAMPLE_DATA_TEMPLATE, idString, pkString, dupsString, sampleString));
-        })
-        .collect(Collectors.toList());
-    MongoCollection<BsonDocument> coll = getMongoClient()
-        .getDatabase(config.getDatabaseName())
-        .getCollection(config.getCollectionName(), BsonDocument.class);
-    coll.insertMany(sampleDocuments);
-  }
-
-  /**
-   * Creates complex sample data
-   *
-   * @param numberOfDocuments the total number of documents to create
-   * @param sizeInMB the total size of the documents
-   * @param config the config used for the database and collection
-   */
-  public void loadComplexSampleData(
-      final int numberOfDocuments, final int sizeInMB, final MongoConfig config) {
-    if (!isOnline()) {
-      return;
-    }
-    int sizeBytes = sizeInMB * 1000 * 1000;
-    int totalDocumentSize = sizeBytes / numberOfDocuments;
-    int sampleDataWithEmptySampleStringSize = RawBsonDocument.parse(
-            format(COMPLEX_SAMPLE_DATA_TEMPLATE, "00000", "_10000", "00000", 1, ""))
-        .getByteBuffer()
-        .limit();
-    String sampleString =
-        RandomStringUtils.randomAlphabetic(totalDocumentSize - sampleDataWithEmptySampleStringSize);
-
-    List<BsonDocument> sampleDocuments = IntStream.range(0, numberOfDocuments)
-        .boxed()
-        .map(i -> {
-          String idString = StringUtils.leftPad(i.toString(), 5, "0");
-          String pkString = format("_%s", i + 10000);
-          String dupsString = StringUtils.leftPad(format("%s", i % 3 == 0 ? 0 : i), 5, "0");
-          return RawBsonDocument.parse(format(
-              COMPLEX_SAMPLE_DATA_TEMPLATE, idString, pkString, dupsString, i % 10, sampleString));
+              format(template, idString, pkString, dupsString, i % 10, sampleString));
         })
         .collect(Collectors.toList());
     MongoCollection<BsonDocument> coll = getMongoClient()

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorTestCase.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorTestCase.java
@@ -155,6 +155,18 @@ public class MongoSparkConnectorTestCase {
     HELPER.loadSampleData(numberOfDocuments, sizeInMB, config);
   }
 
+  /**
+   * Creates complex sample data
+   *
+   * @param numberOfDocuments the total number of documents to create
+   * @param sizeInMB the total size of the documents
+   * @param config the config used for the database and collection
+   */
+  public void loadComplexSampleData(
+      final int numberOfDocuments, final int sizeInMB, final MongoConfig config) {
+    HELPER.loadComplexSampleData(numberOfDocuments, sizeInMB, config);
+  }
+
   /** Runs events with the profiler on. */
   public void assertCommentsInProfile(final Runnable runnable, final ReadConfig readConfig) {
     assumeFalse(isSharded());

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.spark.sql.connector.read.partitioner;
+
+import static com.mongodb.spark.sql.connector.config.MongoConfig.COMMENT_CONFIG;
+import static com.mongodb.spark.sql.connector.config.ReadConfig.PARTITIONER_OPTIONS_PREFIX;
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.PARTITION_CHUNK_SIZE_MB_CONFIG;
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.PARTITION_FIELD_LIST_CONFIG;
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.SAMPLES_PER_PARTITION_CONFIG;
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.createMongoInputPartitions;
+import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.SINGLE_PARTITIONER;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.exceptions.ConfigException;
+import com.mongodb.spark.sql.connector.read.MongoInputPartition;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+
+public class AutoBucketPartitionerTest extends PartitionerTestCase {
+
+  private static final Partitioner PARTITIONER = new AutoBucketPartitioner();
+  private static final String PARTITION_FIELD_KEY = "__idx";
+
+  @Override
+  List<String> defaultReadConfigOptions() {
+    return asList(
+        ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG,
+        "1",
+        ReadConfig.PARTITIONER_OPTIONS_PREFIX + SamplePartitioner.SAMPLES_PER_PARTITION_CONFIG,
+        "10");
+  }
+
+  @Test
+  void testNonExistentCollection() {
+    ReadConfig readConfig = createReadConfig("nonExist");
+    List<MongoInputPartition> partitions = PARTITIONER.generatePartitions(readConfig);
+    assertIterableEquals(SINGLE_PARTITIONER.generatePartitions(readConfig), partitions);
+  }
+
+  @Test
+  void testFewerRecordsThanData() {
+    ReadConfig readConfig = createReadConfig(
+        "few", ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG, "4");
+    loadSampleData(10, 2, readConfig);
+
+    List<MongoInputPartition> partitions = PARTITIONER.generatePartitions(readConfig);
+    assertIterableEquals(SINGLE_PARTITIONER.generatePartitions(readConfig), partitions);
+
+    readConfig = createReadConfig(
+        "few", ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG, "2");
+    partitions = PARTITIONER.generatePartitions(readConfig);
+    assertIterableEquals(SINGLE_PARTITIONER.generatePartitions(readConfig), partitions);
+  }
+
+  @Test
+  void testCreatesExpectedPartitions() {
+    ReadConfig readConfig = createReadConfig("expected");
+    loadSampleData(51, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": \"00009\"}}",
+            "{\"_id\": {\"min\": \"00009\", \"max\": \"00018\"}}",
+            "{\"_id\": {\"min\": \"00018\", \"max\": \"00027\"}}",
+            "{\"_id\": {\"min\": \"00027\", \"max\": \"00036\"}}",
+            "{\"_id\": {\"min\": \"00036\", \"max\": \"00045\"}}",
+            "{\"_id\": {\"min\": \"00045\", \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        singletonList("_id"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(51, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testUsingAlternativePartitionField() {
+    ReadConfig readConfig = createReadConfig(
+        "alt", ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG, "pk");
+    loadSampleData(52, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": \"_10009\"}}",
+            "{\"_id\": {\"min\": \"_10009\", \"max\": \"_10018\"}}",
+            "{\"_id\": {\"min\": \"_10018\", \"max\": \"_10027\"}}",
+            "{\"_id\": {\"min\": \"_10027\", \"max\": \"_10036\"}}",
+            "{\"_id\": {\"min\": \"_10036\", \"max\": \"_10045\"}}",
+            "{\"_id\": {\"min\": \"_10045\", \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        singletonList("pk"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(52, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testUsingPartitionFieldThatContainsDuplicates() {
+    ReadConfig readConfig =
+        createReadConfig("dups", PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG, "dups");
+    loadSampleData(101, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": \"00001\"}}",
+            "{\"_id\": {\"min\": \"00001\", \"max\": \"00026\"}}",
+            "{\"_id\": {\"min\": \"00026\", \"max\": \"00052\"}}",
+            "{\"_id\": {\"min\": \"00052\", \"max\": \"00077\"}}",
+            "{\"_id\": {\"min\": \"00077\", \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        singletonList("dups"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(101, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testCreatesExpectedPartitionsWithUsersPipeline() {
+    ReadConfig readConfig = createReadConfig(
+        "pipeline",
+        ReadConfig.AGGREGATION_PIPELINE_CONFIG,
+        "{'$match': {'_id': {'$gt': '00010', '$lte': '00045'}}}");
+    List<BsonDocument> userSuppliedPipeline =
+        singletonList(BsonDocument.parse("{'$match': {'_id': {'$gt': '00010', '$lte': '00045'}}}"));
+
+    // No data
+    assertIterableEquals(
+        SINGLE_PARTITIONER.generatePartitions(readConfig),
+        PARTITIONER.generatePartitions(readConfig));
+
+    loadSampleData(55, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": \"00020\"}}",
+            "{\"_id\": {\"min\": \"00020\", \"max\": \"00029\"}}",
+            "{\"_id\": {\"min\": \"00029\", \"max\": \"00038\"}}",
+            "{\"_id\": {\"min\": \"00038\", \"max\": \"IGNORED\"}}"),
+        userSuppliedPipeline,
+        singletonList("_id"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(35, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testUsingCompoundPartitionFieldThatContainsDuplicates() {
+    ReadConfig readConfig = createReadConfig(
+        "compound", PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG, "pk,dups");
+    loadSampleData(250, 10, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": {\"0\": \"_10025\", \"1\": \"00025\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10025\", \"1\": \"00025\"}, \"max\": {\"0\": \"_10050\", \"1\": \"00050\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10050\", \"1\": \"00050\"}, \"max\": {\"0\": \"_10075\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10075\", \"1\": \"00000\"}, \"max\": {\"0\": \"_10100\", \"1\": \"00100\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10100\", \"1\": \"00100\"}, \"max\": {\"0\": \"_10125\", \"1\": \"00125\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10125\", \"1\": \"00125\"}, \"max\": {\"0\": \"_10150\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10150\", \"1\": \"00000\"}, \"max\": {\"0\": \"_10175\", \"1\": \"00175\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10175\", \"1\": \"00175\"}, \"max\": {\"0\": \"_10200\", \"1\": \"00200\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10200\", \"1\": \"00200\"}, \"max\": {\"0\": \"_10225\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"_10225\", \"1\": \"00000\"}, \"max\": \"IGNORED\"}}}"),
+        emptyList(),
+        asList("pk", "dups"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(250, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testNestedField() {
+    ReadConfig readConfig = createReadConfig(
+        "nested", PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG, "nested.pk");
+    loadComplexSampleData(60, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": \"_10012\"}}",
+            "{\"_id\": {\"min\": \"_10012\", \"max\": \"_10024\"}}",
+            "{\"_id\": {\"min\": \"_10024\", \"max\": \"_10036\"}}",
+            "{\"_id\": {\"min\": \"_10036\", \"max\": \"_10048\"}}",
+            "{\"_id\": {\"min\": \"_10048\", \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        singletonList("nested.pk"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(60, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testCompoundWithNestedField() {
+    ReadConfig readConfig = createReadConfig(
+        "compoundWithNested",
+        PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG,
+        "_id, nested.dups");
+    loadComplexSampleData(300, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": {\"0\": \"00060\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00060\", \"1\": \"00000\"}, \"max\": {\"0\": \"00120\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00120\", \"1\": \"00000\"}, \"max\": {\"0\": \"00180\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00180\", \"1\": \"00000\"}, \"max\": {\"0\": \"00240\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00240\", \"1\": \"00000\"}, \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        asList("_id", "nested.dups"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(300, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testWorksWithHashedShardKeys() {
+    assumeTrue(isSharded());
+    assumeTrue(isAtLeastFourDotFour());
+
+    ReadConfig readConfig = createReadConfig("simpleHashed");
+    shardCollection(readConfig.getNamespace(), "{\"_id\": \"hashed\"}");
+
+    loadSampleData(51, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": \"00009\"}}",
+            "{\"_id\": {\"min\": \"00009\", \"max\": \"00018\"}}",
+            "{\"_id\": {\"min\": \"00018\", \"max\": \"00027\"}}",
+            "{\"_id\": {\"min\": \"00027\", \"max\": \"00036\"}}",
+            "{\"_id\": {\"min\": \"00036\", \"max\": \"00045\"}}",
+            "{\"_id\": {\"min\": \"00045\", \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        singletonList("_id"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(51, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void testWorksWithCompoundAndHashedShardKeys() {
+    assumeTrue(isSharded());
+    assumeTrue(isAtLeastFourDotFour());
+    ReadConfig readConfig = createReadConfig(
+        "complexHashed",
+        PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG,
+        "_id, nested.dups");
+
+    shardCollection(readConfig.getNamespace(), "{\"_id\": 1, \"nested,dups\": \"hashed\"}");
+    loadComplexSampleData(300, 10, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = createMongoInputPartitions(
+        toBsonDocuments(
+            "{\"_id\": {\"min\": \"IGNORED\", \"max\": {\"0\": \"00030\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00030\", \"1\": \"00000\"}, \"max\": {\"0\": \"00060\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00060\", \"1\": \"00000\"}, \"max\": {\"0\": \"00090\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00090\", \"1\": \"00000\"}, \"max\": {\"0\": \"00120\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00120\", \"1\": \"00000\"}, \"max\": {\"0\": \"00150\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00150\", \"1\": \"00000\"}, \"max\": {\"0\": \"00180\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00180\", \"1\": \"00000\"}, \"max\": {\"0\": \"00210\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00210\", \"1\": \"00000\"}, \"max\": {\"0\": \"00240\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00240\", \"1\": \"00000\"}, \"max\": {\"0\": \"00270\", \"1\": \"00000\"}}}",
+            "{\"_id\": {\"min\": {\"0\": \"00270\", \"1\": \"00000\"}, \"max\": \"IGNORED\"}}"),
+        emptyList(),
+        asList("_id", "nested.dups"),
+        PARTITION_FIELD_KEY,
+        getPreferredLocations());
+
+    assertIterableEquals(expectedPartitions, PARTITIONER.generatePartitions(readConfig));
+    assertEquals(300, getDataSetCount(readConfig));
+  }
+
+  @Test
+  void shouldValidateReadConfigs() {
+    loadSampleData(50, 2, createReadConfig("validate"));
+
+    assertAll(
+        () -> assertThrows(
+            ConfigException.class,
+            () -> PARTITIONER.generatePartitions(createReadConfig(
+                "validate", PARTITIONER_OPTIONS_PREFIX + SAMPLES_PER_PARTITION_CONFIG, "-1")),
+            SAMPLES_PER_PARTITION_CONFIG + " is negative"),
+        () -> assertThrows(
+            ConfigException.class,
+            () -> PARTITIONER.generatePartitions(createReadConfig(
+                "validate", PARTITIONER_OPTIONS_PREFIX + SAMPLES_PER_PARTITION_CONFIG, "0")),
+            SAMPLES_PER_PARTITION_CONFIG + " is zero"),
+        () -> assertThrows(
+            ConfigException.class,
+            () -> PARTITIONER.generatePartitions(createReadConfig(
+                "validate", PARTITIONER_OPTIONS_PREFIX + SAMPLES_PER_PARTITION_CONFIG, "1")),
+            SAMPLES_PER_PARTITION_CONFIG + " is one"),
+        () -> assertThrows(
+            ConfigException.class,
+            () -> PARTITIONER.generatePartitions(createReadConfig(
+                "validate", PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG, "-1")),
+            PARTITION_CHUNK_SIZE_MB_CONFIG + " is negative"),
+        () -> assertThrows(
+            ConfigException.class,
+            () -> PARTITIONER.generatePartitions(createReadConfig(
+                "validate", PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG, "0")),
+            PARTITION_CHUNK_SIZE_MB_CONFIG + " is zero"));
+  }
+
+  @Test
+  void shouldLogCommentsInProfilerLogs() {
+    ReadConfig readConfig = createReadConfig("commentInLogs");
+    loadSampleData(50, 1, readConfig);
+
+    ReadConfig configWithComment = readConfig.withOption(COMMENT_CONFIG, TEST_COMMENT);
+    assertCommentsInProfile(
+        () -> PARTITIONER.generatePartitions(configWithComment), configWithComment);
+  }
+
+  private long getDataSetCount(final ReadConfig readConfig) {
+    return getOrCreateSparkSession()
+        .read()
+        .format("mongodb")
+        .options(readConfig.getOptions())
+        .load()
+        .count();
+  }
+
+  private static List<BsonDocument> toBsonDocuments(final String... json) {
+    return Arrays.stream(json).map(BsonDocument::parse).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/assertions/Assertions.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/assertions/Assertions.java
@@ -25,6 +25,20 @@ import java.util.function.Supplier;
 public final class Assertions {
 
   /**
+   * Asserts is true
+   *
+   * @param assertionCheck the supplier of the assertion check
+   * @param errorMessageSupplier the supplier of the error message if the predicate
+   * @throws AssertionError if the state check fails
+   */
+  public static void assertTrue(
+      final Supplier<Boolean> assertionCheck, final Supplier<String> errorMessageSupplier) {
+    if (!assertionCheck.get()) {
+      throw new AssertionError(errorMessageSupplier.get());
+    }
+  }
+
+  /**
    * Ensures the validity of state
    *
    * @param stateCheck the supplier of the state check

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.spark.sql.connector.read.partitioner;
+
+import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.SINGLE_PARTITIONER;
+import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.getPreferredLocations;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.spark.sql.connector.assertions.Assertions;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.read.MongoInputPartition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.VisibleForTesting;
+
+/**
+ * Auto Bucket Partitioner
+ *
+ * <p>A $sample based partitioner that provides support for all collection types.
+ * Supports partitioning across single or multiple fields, including nested fields.
+ *
+ * <p>The logic for the partitioner is as follows:</p>
+ * <ul>
+ *      <li>Calculate the number of documents per partition.<br>
+ *       Runs a {@code $collStats} aggregation to get the average document size.</li>
+ *       <li>Determines the total count of documents.<br>
+ *          Uses the {@code $collStats} count or by running a {@code countDocuments} query
+ *          if the user supplies their own {@code "aggregation.pipeline" } configuration.</li>
+ *      <li>Determines the number of partitions.<br>
+ *      Calculated as: {@code count / number of documents per partition}
+ *      </li>
+ *      <li>Determines the number of documents to {@code $sample}.<br>
+ *      Calculated as: {@code samples per partition * number of partitions}.</li>
+ *      <li>Creates the aggregation pipeline to generate the partitions.<br>
+ *         <pre><code>
+ *             [{$match: &lt;the $match stage of the users aggregation pipeline - iff the first stage is a $match&gt;},
+ *              {$sample: &lt;number of documents to $sample&gt;},
+ *              // The next stage is only added iff fieldList.size() &gt; 1
+ *              {$addFields: {&lt;partition key projection field&gt;: {&lt;'i': '$fieldList[i]' ...&gt;}}
+ *              {$bucketAuto: {
+ *                      groupBy: &lt;partition key projection field&gt;,
+ *                      buckets: &lt;number of partitions&gt;
+ *                  }
+ *              }]
+ *        </code></pre>
+ *      </li>
+ *  </ul>
+ *
+ * <p>Configurations:</p>
+ * <ul>
+ *   <li>{@value PARTITION_FIELD_LIST_CONFIG}: The field list to be used for partitioning.
+ *   Either a single field name or a list of comma separated fields. Defaults to: {@value ID}.
+ *   <li>{@value PARTITION_CHUNK_SIZE_MB_CONFIG }: The average size (MB) for each partition.<br>
+ *     <strong>Note:</strong> Uses the average document size to determine the number of documents per partition
+ *     so partitions may not be even.<br> Defaults to: {@value PARTITION_CHUNK_SIZE_MB_DEFAULT}.
+ *   <li>{@value SAMPLES_PER_PARTITION_CONFIG}: The number of samples to take per partition.<br>
+ *       Defaults to: {@value SAMPLES_PER_PARTITION_DEFAULT}.
+ *   <li>{@value PARTITION_KEY_PROJECTION_FIELD_CONFIG}: The field name to use for a projected field that contains all the
+ *       fields used to partition the collection.<br>
+ *       Defaults to: {@value PARTITION_KEY_PROJECTION_FIELD_DEFAULT}.<br>
+ *       Recommended to only change if there already is a {@value PARTITION_KEY_PROJECTION_FIELD_DEFAULT} field in the document.
+ * </ul>
+ *
+ * <p>Partitions are calculated as logical ranges. When using sharded clusters these will map closely to ranged chunks.
+ * When using with hashed shard keys these logical ranges require broadcast operations.
+ *
+ * <p>Similar to the {@link SamplePartitioner} however uses the
+ * <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/">$bucketAuto</a> aggregation stage
+ * to generate the partition bounds.
+ *
+ * {@inheritDoc}
+ */
+@ApiStatus.Internal
+public final class AutoBucketPartitioner implements Partitioner {
+
+  private static final String ID = "_id";
+  private static final String MIN = "min";
+  private static final String MAX = "max";
+  private static final String LT = "$lt";
+  private static final String GTE = "$gte";
+
+  public static final String PARTITION_FIELD_LIST_CONFIG = "fieldList";
+  private static final List<String> PARTITION_FIELD_LIST_DEFAULT = singletonList(ID);
+
+  public static final String PARTITION_CHUNK_SIZE_MB_CONFIG = "chunkSize";
+  private static final int PARTITION_CHUNK_SIZE_MB_DEFAULT = 64;
+
+  public static final String SAMPLES_PER_PARTITION_CONFIG = "samplesPerPartition";
+  private static final int SAMPLES_PER_PARTITION_DEFAULT = 10;
+
+  public static final String PARTITION_KEY_PROJECTION_FIELD_CONFIG = "partitionKeyProjectionField";
+  private static final String PARTITION_KEY_PROJECTION_FIELD_DEFAULT = "__idx";
+
+  /** Construct an instance */
+  public AutoBucketPartitioner() {}
+
+  @Override
+  public List<MongoInputPartition> generatePartitions(final ReadConfig readConfig) {
+    MongoConfig partitionerOptions = readConfig.getPartitionerOptions();
+
+    List<String> partitionFieldList = Assertions.validateConfig(
+        partitionerOptions.getList(PARTITION_FIELD_LIST_CONFIG, PARTITION_FIELD_LIST_DEFAULT),
+        i -> !i.isEmpty(),
+        () -> format("Invalid config: %s must not be empty.", PARTITION_FIELD_LIST_CONFIG));
+
+    long partitionSizeInBytes = Assertions.validateConfig(
+            partitionerOptions.getInt(
+                PARTITION_CHUNK_SIZE_MB_CONFIG, PARTITION_CHUNK_SIZE_MB_DEFAULT),
+            i -> i > 0,
+            () -> format(
+                "Invalid config: %s should be greater than zero.", PARTITION_CHUNK_SIZE_MB_CONFIG))
+        * 1000
+        * 1000;
+
+    int samplesPerPartition = Assertions.validateConfig(
+        partitionerOptions.getInt(SAMPLES_PER_PARTITION_CONFIG, SAMPLES_PER_PARTITION_DEFAULT),
+        i -> i > 1,
+        () ->
+            format("Invalid config: %s should be greater than one.", SAMPLES_PER_PARTITION_CONFIG));
+
+    String partitionProjectionKey = partitionerOptions.getOrDefault(
+        PARTITION_KEY_PROJECTION_FIELD_CONFIG, PARTITION_KEY_PROJECTION_FIELD_DEFAULT);
+
+    BsonDocument storageStats = PartitionerHelper.storageStats(readConfig);
+    if (storageStats.isEmpty()) {
+      LOGGER.warn("Unable to get collection stats (collstats) returning a single partition.");
+      return SINGLE_PARTITIONER.generatePartitions(readConfig);
+    }
+
+    double avgObjSizeInBytes =
+        storageStats.get("avgObjSize", new BsonInt32(0)).asNumber().doubleValue();
+    double numDocumentsPerPartition = Math.floor(partitionSizeInBytes / avgObjSizeInBytes);
+
+    BsonDocument usersMatchQuery =
+        PartitionerHelper.matchQuery(readConfig.getAggregationPipeline());
+    long count;
+    if (usersMatchQuery.isEmpty() && storageStats.containsKey("count")) {
+      count = storageStats.getNumber("count").longValue();
+    } else {
+      count = readConfig.withCollection(coll -> coll.countDocuments(
+          usersMatchQuery, new CountOptions().comment(readConfig.getComment())));
+    }
+
+    if (numDocumentsPerPartition >= count) {
+      LOGGER.info(
+          "Fewer documents ({}) than the calculated number of documents per partition ({}). Returning a single partition",
+          count,
+          numDocumentsPerPartition);
+      return SINGLE_PARTITIONER.generatePartitions(readConfig);
+    }
+
+    int numberOfBuckets = (int) Math.ceil(count / numDocumentsPerPartition);
+    int numberOfSamples = (int) Math.ceil(samplesPerPartition * numDocumentsPerPartition);
+
+    List<BsonDocument> buckets =
+        readConfig.withCollection(coll -> coll.aggregate(createBucketAutoPipeline(
+                usersMatchQuery,
+                partitionFieldList,
+                partitionProjectionKey,
+                numberOfSamples,
+                numberOfBuckets))
+            .allowDiskUse(readConfig.getAggregationAllowDiskUse())
+            .comment(readConfig.getComment())
+            .into(new ArrayList<>()));
+
+    return createMongoInputPartitions(
+        buckets,
+        readConfig.getAggregationPipeline(),
+        partitionFieldList,
+        partitionProjectionKey,
+        getPreferredLocations(readConfig));
+  }
+
+  /**
+   * Creates the $sample and $bucketAuto aggregation pipeline used for determining the partition bounds.
+   *
+   * @param usersMatchQuery the match part of a user supplied aggregation pipeline or an empty document
+   * @param partitionFieldList the fields to partition the collection by
+   * @param partitionProjectionKey the partition projection key only used if there are multiple partition fields
+   * @param numberOfSamples the number of samples
+   * @param numberOfBuckets the number of buckets
+   * @return the pipeline
+   */
+  @VisibleForTesting
+  static List<BsonDocument> createBucketAutoPipeline(
+      final BsonDocument usersMatchQuery,
+      final List<String> partitionFieldList,
+      final String partitionProjectionKey,
+      final int numberOfSamples,
+      final int numberOfBuckets) {
+
+    List<BsonDocument> pipeline = new ArrayList<>();
+    if (!usersMatchQuery.isEmpty()) {
+      pipeline.add(new BsonDocument("$match", usersMatchQuery));
+    }
+    pipeline.add(
+        new BsonDocument("$sample", new BsonDocument("size", new BsonInt32(numberOfSamples))));
+
+    if (partitionFieldList.size() > 1) {
+      pipeline.add(addFieldsStage(partitionFieldList, partitionProjectionKey));
+    }
+
+    String groupByField =
+        partitionFieldList.size() == 1 ? partitionFieldList.get(0) : partitionProjectionKey;
+
+    BsonDocument bucketAuto = new BsonDocument();
+    bucketAuto.put("groupBy", new BsonString("$" + groupByField));
+    bucketAuto.put("buckets", new BsonInt32(numberOfBuckets));
+    pipeline.add(new BsonDocument("$bucketAuto", bucketAuto));
+
+    return pipeline;
+  }
+
+  @VisibleForTesting
+  static List<MongoInputPartition> createMongoInputPartitions(
+      final List<BsonDocument> buckets,
+      final List<BsonDocument> usersPipeline,
+      final List<String> partitionFieldList,
+      final String partitionProjectionKey,
+      final List<String> preferredLocations) {
+
+    Assertions.ensureArgument(
+        () -> buckets.size() > 1,
+        () -> format(
+            "Unexpected auto bucketing size, expected more than one bucket. Got: %s.",
+            buckets.stream().map(BsonDocument::toJson).collect(Collectors.joining(",", "[", "]"))));
+
+    String matchField =
+        partitionFieldList.size() == 1 ? partitionFieldList.get(0) : partitionProjectionKey;
+    int finalBoundsIndex = buckets.size() - 1;
+    List<MongoInputPartition> inputPartitions = new ArrayList<>();
+
+    for (int i = 0; i < buckets.size(); i++) {
+      BsonDocument bucket = buckets.get(i);
+      Assertions.ensureArgument(
+          () -> bucket.containsKey(ID) && bucket.isDocument(ID),
+          () -> format(
+              "Unexpected auto bucket format %s field required. Got: %s.", ID, bucket.toJson()));
+      BsonDocument bounds = bucket.getDocument(ID);
+
+      Assertions.ensureArgument(
+          () -> bounds.containsKey(MIN) && bounds.containsKey(MAX),
+          () -> format(
+              "Unexpected auto bucket format. Expected %s and %s ranges got: %s.",
+              MIN, MAX, bounds.toJson()));
+
+      boolean includeMin = i > 0;
+      boolean includeMax = i < finalBoundsIndex;
+
+      BsonDocument partitionBounds = new BsonDocument();
+      if (includeMin) {
+        partitionBounds.put(GTE, bounds.get(MIN));
+      }
+      if (includeMax) {
+        partitionBounds.put(LT, bounds.get(MAX));
+      }
+      BsonDocument partitionBoundsMatch =
+          new BsonDocument("$match", new BsonDocument(matchField, partitionBounds));
+
+      List<BsonDocument> partitionPipeline = createPartitionPipeline(
+          partitionFieldList, partitionProjectionKey, partitionBoundsMatch, usersPipeline);
+      inputPartitions.add(new MongoInputPartition(i, partitionPipeline, preferredLocations));
+    }
+    return inputPartitions;
+  }
+
+  /**
+   * Creates the aggregation pipeline for the partition
+   *
+   * @param partitionFieldList the fields to partition the collection by
+   * @param partitionProjectionKey the partition projection key only used if there are multiple partition fields
+   * @param partitionBounds the calculated partition bounds $match query
+   * @param usersPipeline the configured user supplied aggregation pipeline
+   * @return
+   */
+  @VisibleForTesting
+  static List<BsonDocument> createPartitionPipeline(
+      final List<String> partitionFieldList,
+      final String partitionProjectionKey,
+      final BsonDocument partitionBounds,
+      final List<BsonDocument> usersPipeline) {
+    List<BsonDocument> partitionPipeline = new ArrayList<>();
+
+    if (partitionFieldList.size() > 1) {
+      partitionPipeline.add(addFieldsStage(partitionFieldList, partitionProjectionKey));
+    }
+
+    partitionPipeline.add(partitionBounds);
+
+    if (partitionFieldList.size() > 1) {
+      partitionPipeline.add(new BsonDocument("$unset", new BsonString(partitionProjectionKey)));
+    }
+    partitionPipeline.addAll(usersPipeline);
+    return partitionPipeline;
+  }
+
+  /**
+   * Adds a new document to match against containing the values of the partition field list fields.
+   *
+   * <p>Uses a numeric index so sub documents can be supported when partitioning the collection.
+   *
+   * @param partitionFieldList the fields to partition the collection by
+   * @param partitionProjectionKey the partition projection key only used if there are multiple partition fields
+   * @return the $addFields pipeline stage
+   */
+  private static BsonDocument addFieldsStage(
+      final List<String> partitionFieldList, final String partitionProjectionKey) {
+    BsonDocument addFieldValue = new BsonDocument();
+    for (int i = 0; i < partitionFieldList.size(); i++) {
+      addFieldValue.put(String.valueOf(i), new BsonString("$" + partitionFieldList.get(i)));
+    }
+    return new BsonDocument("$addFields", new BsonDocument(partitionProjectionKey, addFieldValue));
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -267,15 +267,14 @@ public final class AutoBucketPartitioner implements Partitioner {
       boolean includeMin = i > 0;
       boolean includeMax = i < buckets.size() - 1;
 
-      BsonDocument partitionBounds = new BsonDocument();
+      List<Bson> partitionBounds = new ArrayList<>();
       if (includeMin) {
-        partitionBounds.put(GTE, bounds.get(MIN));
+        partitionBounds.add(Filters.gte(matchField, bounds.get(MIN)));
       }
       if (includeMax) {
-        partitionBounds.put(LT, bounds.get(MAX));
+        partitionBounds.add(Filters.lt(matchField, bounds.get(MAX)));
       }
-      BsonDocument partitionBoundsMatch =
-          new BsonDocument("$match", new BsonDocument(matchField, partitionBounds));
+      BsonDocument partitionBoundsMatch = Aggregates.match(Filters.and(partitionBounds)).toBsonDocument();
 
       List<BsonDocument> partitionPipeline = createPartitionPipeline(
           partitionFieldList, partitionProjectionKey, partitionBoundsMatch, usersPipeline);

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -173,7 +173,7 @@ public final class AutoBucketPartitioner implements Partitioner {
     }
 
     int numberOfBuckets = Math.toIntExact((long) Math.ceil(count / numDocumentsPerPartition));
-    int numberOfSamples = Math.toIntExact((long) (double) (samplesPerPartition * numberOfBuckets));
+    int numberOfSamples = Math.toIntExact((long) samplesPerPartition * numberOfBuckets);
 
     List<BsonDocument> buckets =
         readConfig.withCollection(coll -> coll.aggregate(createBucketAutoPipeline(

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -268,7 +268,7 @@ public final class AutoBucketPartitioner implements Partitioner {
               MIN, MAX, bounds.toJson()));
 
       boolean includeMin = i > 0;
-      boolean includeMax = i < finalBoundsIndex;
+      boolean includeMax = i < buckets.size() - 1;
 
       BsonDocument partitionBounds = new BsonDocument();
       if (includeMin) {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -311,7 +311,7 @@ public final class AutoBucketPartitioner implements Partitioner {
     partitionPipeline.add(partitionBounds);
 
     if (partitionFieldList.size() > 1) {
-      partitionPipeline.add(new BsonDocument("$unset", new BsonString(partitionProjectionKey)));
+      partitionPipeline.add(Aggregates.unset(partitionProjectionKey).toBsonDocument());
     }
     partitionPipeline.addAll(usersPipeline);
     return partitionPipeline;

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -217,7 +217,7 @@ public final class AutoBucketPartitioner implements Partitioner {
       pipeline.add(Aggregates.match(usersMatchQuery).toBsonDocument());
     }
     pipeline.add(
-        new BsonDocument("$sample", new BsonDocument("size", new BsonInt32(numberOfSamples))));
+        Aggregates.sample(numberOfSamples).toBsonDocument());
 
     if (partitionFieldList.size() > 1) {
       pipeline.add(addFieldsStage(partitionFieldList, partitionProjectionKey));

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -172,8 +172,8 @@ public final class AutoBucketPartitioner implements Partitioner {
       return SINGLE_PARTITIONER.generatePartitions(readConfig);
     }
 
-    int numberOfBuckets = (int) Math.ceil(count / numDocumentsPerPartition);
-    int numberOfSamples = (int) Math.ceil(samplesPerPartition * numDocumentsPerPartition);
+    int numberOfBuckets = Math.toIntExact((long) Math.ceil(count / numDocumentsPerPartition));
+    int numberOfSamples = Math.toIntExact((long) Math.ceil(samplesPerPartition * numDocumentsPerPartition));```
 
     List<BsonDocument> buckets =
         readConfig.withCollection(coll -> coll.aggregate(createBucketAutoPipeline(

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -224,7 +224,7 @@ public final class AutoBucketPartitioner implements Partitioner {
     }
 
     String groupByField =
-        partitionFieldList.size() == 1 ? partitionFieldList.get(0) : partitionProjectionKey;
+        partitionFieldList.size() > 1 ? partitionProjectionKey : partitionFieldList.get(0);
 
     BsonDocument bucketAuto = new BsonDocument();
     bucketAuto.put("groupBy", new BsonString("$" + groupByField));

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -332,6 +332,7 @@ public final class AutoBucketPartitioner implements Partitioner {
     for (int i = 0; i < partitionFieldList.size(); i++) {
       addFieldValue.put(String.valueOf(i), new BsonString("$" + partitionFieldList.get(i)));
     }
-    return new BsonDocument("$addFields", new BsonDocument(partitionProjectionKey, addFieldValue));
+    return Aggregates.addFields(new Field<>(partitionProjectionKey, addFieldValue))
+        .toBsonDocument();
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -226,10 +226,7 @@ public final class AutoBucketPartitioner implements Partitioner {
     String groupByField =
         partitionFieldList.size() > 1 ? partitionProjectionKey : partitionFieldList.get(0);
 
-    BsonDocument bucketAuto = new BsonDocument();
-    bucketAuto.put("groupBy", new BsonString("$" + groupByField));
-    bucketAuto.put("buckets", new BsonInt32(numberOfBuckets));
-    pipeline.add(new BsonDocument("$bucketAuto", bucketAuto));
+    pipeline.add(Aggregates.bucketAuto("$" + groupByField, numberOfBuckets).toBsonDocument());
 
     return pipeline;
   }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -214,7 +214,7 @@ public final class AutoBucketPartitioner implements Partitioner {
 
     List<BsonDocument> pipeline = new ArrayList<>();
     if (!usersMatchQuery.isEmpty()) {
-      pipeline.add(new BsonDocument("$match", usersMatchQuery));
+      pipeline.add(Aggregates.match(usersMatchQuery).toBsonDocument());
     }
     pipeline.add(
         new BsonDocument("$sample", new BsonDocument("size", new BsonInt32(numberOfSamples))));

--- a/src/test/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerUnitTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerUnitTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.spark.sql.connector.read.partitioner;
+
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.createBucketAutoPipeline;
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.createMongoInputPartitions;
+import static com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner.createPartitionPipeline;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.mongodb.spark.sql.connector.read.MongoInputPartition;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+
+public class AutoBucketPartitionerUnitTest {
+  private static final BsonDocument EMPTY_DOCUMENT = new BsonDocument();
+
+  @Test
+  void testCreateBucketAutoPipeline() {
+    // When no users pipeline and a single field
+    assertPipeline(
+        asList(
+            "{\"$sample\": {\"size\": 1000}}",
+            "{\"$bucketAuto\": {\"groupBy\": \"$a\", \"buckets\": 10}}"),
+        createBucketAutoPipeline(EMPTY_DOCUMENT, singletonList("a"), "__idx", 1000, 10));
+
+    // When no users pipeline and a multiple fields
+    assertPipeline(
+        asList(
+            "{\"$sample\": {\"size\": 101}}",
+            "{\"$addFields\": {\"__ab\": {\"0\": \"$a\", \"1\": \"$b\"}}}",
+            "{\"$bucketAuto\": {\"groupBy\": \"$__ab\", \"buckets\": 5}}"),
+        createBucketAutoPipeline(EMPTY_DOCUMENT, asList("a", "b"), "__ab", 101, 5));
+
+    // When no users pipeline and dotted fields
+    assertPipeline(
+        asList(
+            "{\"$sample\": {\"size\": 99}}",
+            "{\"$addFields\": {\"__abc\": {\"0\": \"$a.b\", \"1\": \"$c\"}}}",
+            "{\"$bucketAuto\": {\"groupBy\": \"$__abc\", \"buckets\": 9}}"),
+        createBucketAutoPipeline(EMPTY_DOCUMENT, asList("a.b", "c"), "__abc", 99, 9));
+
+    // With users pipeline
+    assertPipeline(
+        asList(
+            "{\"$match\": {\"b\": {\"$gte\": 99}}}",
+            "{\"$sample\": {\"size\": 1000}}",
+            "{\"$bucketAuto\": {\"groupBy\": \"$a\", \"buckets\": 10}}"),
+        createBucketAutoPipeline(
+            BsonDocument.parse("{\"b\": {\"$gte\": 99}}"), singletonList("a"), "a", 1000, 10));
+  }
+
+  @Test
+  void testCreatePartitionPipeline() {
+    // Single field tests
+    List<String> singleFieldList = singletonList("a");
+    List<String> multipleFieldList = asList("a.b", "c");
+    BsonDocument bounds = BsonDocument.parse("{\"$match\": {\"a\": {\"$gte\": 20, \"$lt\": 30}}}");
+    BsonDocument complexBounds = BsonDocument.parse(
+        "{\"$match\": {\"_abc\": {\"$gte\": {\"0\": 20, \"1\": \"z\"}, \"$lt\": {\"0\": 30, \"1\": \"a\"}}}}");
+    List<BsonDocument> usersPipeline =
+        toBsonDocuments("{\"$match\": {\"b\": {\"$gte\": 99}}}", "{\"$project\": {\"_id\": 0}}");
+
+    assertPipeline(
+        singletonList("{\"$match\": {\"a\": {\"$gte\": 20, \"$lt\": 30}}}"),
+        createPartitionPipeline(singleFieldList, "__a", bounds, emptyList()));
+
+    assertPipeline(
+        asList(
+            "{\"$match\": {\"a\": {\"$gte\": 20, \"$lt\": 30}}}",
+            "{\"$match\": {\"b\": {\"$gte\": 99}}}",
+            "{\"$project\": {\"_id\": 0}}"),
+        createPartitionPipeline(singleFieldList, "__a", bounds, usersPipeline));
+
+    // multiple field tests
+    assertPipeline(
+        asList(
+            "{\"$addFields\": {\"_abc\": {\"0\": \"$a.b\", \"1\": \"$c\"}}}",
+            "{\"$match\": {\"_abc\": {\"$gte\": {\"0\": 20, \"1\": \"z\"}, \"$lt\": {\"0\": 30, \"1\": \"a\"}}}}",
+            "{\"$unset\": \"_abc\"}"),
+        createPartitionPipeline(multipleFieldList, "_abc", complexBounds, emptyList()));
+
+    assertPipeline(
+        asList(
+            "{\"$addFields\": {\"_abc\": {\"0\": \"$a.b\", \"1\": \"$c\"}}}",
+            "{\"$match\": {\"_abc\": {\"$gte\": {\"0\": 20, \"1\": \"z\"}, \"$lt\": {\"0\": 30, \"1\": \"a\"}}}}",
+            "{\"$unset\": \"_abc\"}",
+            "{\"$match\": {\"b\": {\"$gte\": 99}}}",
+            "{\"$project\": {\"_id\": 0}}"),
+        createPartitionPipeline(multipleFieldList, "_abc", complexBounds, usersPipeline));
+  }
+
+  @Test
+  void testCreateMongoInputPartitions() {
+    List<String> singleFieldList = singletonList("a");
+    List<String> multipleFieldList = asList("a.b", "c");
+    List<BsonDocument> usersPipeline = toBsonDocuments("{\"$match\": {\"b\": {\"$gte\": 99}}}");
+
+    List<String> preferredLocations = asList("a.example.com", "b.example.com");
+
+    // Single field / no pipeline / no location
+    assertIterableEquals(
+        asList(
+            new MongoInputPartition(
+                0, toBsonDocuments("{\"$match\": {\"a\": { \"$lt\": 250}}}"), emptyList()),
+            new MongoInputPartition(
+                1,
+                toBsonDocuments("{\"$match\": {\"a\": { \"$gte\": 250, \"$lt\": 500}}}"),
+                emptyList()),
+            new MongoInputPartition(
+                2, toBsonDocuments("{\"$match\": {\"a\": { \"$gte\": 500}}}"), emptyList())),
+        createMongoInputPartitions(
+            toBsonDocuments(
+                "{\"_id\": {\"min\": 0, \"max\": 250}}",
+                "{\"_id\": {\"min\": 250, \"max\": 500}}",
+                "{\"_id\": {\"min\": 500, \"max\": 750}}"),
+            emptyList(),
+            singleFieldList,
+            "__idx",
+            emptyList()));
+
+    // Single field with pipeline & location
+    assertIterableEquals(
+        asList(
+            new MongoInputPartition(
+                0,
+                toBsonDocuments(
+                    "{\"$match\": {\"a\": { \"$lt\": 250}}}",
+                    "{\"$match\": {\"b\": {\"$gte\": 99}}}"),
+                preferredLocations),
+            new MongoInputPartition(
+                1,
+                toBsonDocuments(
+                    "{\"$match\": {\"a\": { \"$gte\": 250}}}",
+                    "{\"$match\": {\"b\": {\"$gte\": 99}}}"),
+                preferredLocations)),
+        createMongoInputPartitions(
+            toBsonDocuments(
+                "{\"_id\": {\"min\": 0, \"max\": 250}}", "{\"_id\": {\"min\": 250, \"max\": 500}}"),
+            usersPipeline,
+            singleFieldList,
+            "__idx",
+            preferredLocations));
+
+    // multiple field list with pipeline & location
+    assertIterableEquals(
+        asList(
+            new MongoInputPartition(
+                0,
+                toBsonDocuments(
+                    "{\"$addFields\": {\"__idx\": {\"0\": \"$a.b\", \"1\": \"$c\"}}}",
+                    "{\"$match\": {\"__idx\": { \"$lt\": {\"0\": 250, \"1\": \"z\"}}}}",
+                    "{\"$unset\": \"__idx\"}",
+                    "{\"$match\": {\"b\": {\"$gte\": 99}}}"),
+                preferredLocations),
+            new MongoInputPartition(
+                1,
+                toBsonDocuments(
+                    "{\"$addFields\": {\"__idx\": {\"0\": \"$a.b\", \"1\": \"$c\"}}}",
+                    "{\"$match\": {\"__idx\": { \"$gte\": {\"0\": 250, \"1\": \"z\"}, \"$lt\": {\"0\": 500, \"1\": \"a\"}}}}",
+                    "{\"$unset\": \"__idx\"}",
+                    "{\"$match\": {\"b\": {\"$gte\": 99}}}"),
+                preferredLocations),
+            new MongoInputPartition(
+                2,
+                toBsonDocuments(
+                    "{\"$addFields\": {\"__idx\": {\"0\": \"$a.b\", \"1\": \"$c\"}}}",
+                    "{\"$match\": {\"__idx\": { \"$gte\": {\"0\": 500, \"1\": \"a\"}}}}",
+                    "{\"$unset\": \"__idx\"}",
+                    "{\"$match\": {\"b\": {\"$gte\": 99}}}"),
+                preferredLocations)),
+        createMongoInputPartitions(
+            toBsonDocuments(
+                "{\"_id\": {\"min\": {\"0\": 0, \"1\": \"a\"}, \"max\": {\"0\": 250, \"1\": \"z\"}}}",
+                "{\"_id\": {\"min\": {\"0\": 250, \"1\": \"z\"}, \"max\": {\"0\": 500, \"1\": \"a\"}}}",
+                "{\"_id\": {\"min\": {\"0\": 500, \"1\": \"a\"}, \"max\": {\"0\": 500, \"1\": \"z\"}}}"),
+            usersPipeline,
+            multipleFieldList,
+            "__idx",
+            preferredLocations));
+
+    // Error scenarios
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createMongoInputPartitions(
+            emptyList(), emptyList(), singleFieldList, "a", emptyList()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createMongoInputPartitions(
+            toBsonDocuments("{\"_id\": {\"min\": 0, \"max\": 250}}"),
+            emptyList(),
+            singleFieldList,
+            "a",
+            emptyList()),
+        "Single bounds");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createMongoInputPartitions(
+            toBsonDocuments("{\"min\": 0, \"max\": 250}", "{\"min\": 250, \"max\": 500}"),
+            emptyList(),
+            singleFieldList,
+            "a",
+            emptyList()),
+        "No _id field");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createMongoInputPartitions(
+            toBsonDocuments("{\"_id\": {\"max\": 0}}", "{\"_id\": {\"min\": 250, \"max\": 500}}"),
+            emptyList(),
+            singleFieldList,
+            "a",
+            emptyList()),
+        "Missing min field");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createMongoInputPartitions(
+            toBsonDocuments("{\"_id\": {\"min\": 0}}", "{\"_id\": {\"min\": 250, \"max\": 500}}"),
+            emptyList(),
+            singleFieldList,
+            "a",
+            emptyList()),
+        "Missing max field");
+  }
+
+  private void assertPipeline(final List<String> json, final List<BsonDocument> actual) {
+    List<BsonDocument> expected = toBsonDocuments(json.toArray(new String[0]));
+    assertIterableEquals(
+        expected,
+        actual,
+        () -> "Got : "
+            + actual.stream().map(BsonDocument::toJson).collect(Collectors.joining(",", "[", "]")));
+  }
+
+  private static List<BsonDocument> toBsonDocuments(final String... json) {
+    return Arrays.stream(json).map(BsonDocument::parse).collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
A `$sample` based partitioner that provides support for all collection types. Supports partitioning across single or multiple fields, including nested fields.

The logic for the partitioner is as follows:

- Calculate the number of documents per partition. Runs a `$collStats` aggregation to get the average document size.
- Determines the total count of documents. Uses the `$collStats` count or by running a `countDocuments` query if the user supplies their own `aggregation.pipeline` configuration.
- Determines the number of partitions. Calculated as: `count / number of documents per partition`
- Determines the number of documents to $sample. Calculated as: `samples per partition * number of partitions`.
- Creates the aggregation pipeline to generate the partitions. 
  ```
  [{$match: <the $match stage of the users aggregation pipeline - iff the first stage is a $match>},
   {$sample: <number of documents to $sample>},
   {$addFields: {<partition key projection field>: {<'i': '$fieldList[i]' ...>}} // Only added iff fieldList.size() > 1
   {$bucketAuto: {
          groupBy: <partition key projection field>,
          buckets: <number of partitions>
      }
   }
  ]
  ```

Configurations:

- `fieldList`: The field list to be used for partitioning.
  Either a single field name or a list of comma separated fields.
  Defaults to: "_id".
- `chunkSize`: The average size (MB) for each partition.
  Note: Uses the average document size to determine the number of documents per partition so
  partitions may not be even.
  Defaults to: 64.
- `samplesPerPartition`: The number of samples to take per partition.
  Defaults to: 10.
- `partitionKeyProjectionField`: The field name to use for a projected field that contains all the
  fields used to partition the collection.
  Defaults to: "__idx".
  Recommended to only change if there already is a "__idx" field in the document.

Partitions are calculated as logical ranges. When using sharded clusters these will map closely to ranged chunks.
When using with hashed shard keys these logical ranges require broadcast operations.

Similar to the SamplePartitioner however uses the $bucketAuto aggregation stage to generate the partition bounds.

SPARK-356