### PR TITLE
Allow reuse of MongoClient instances for the same collection

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactory.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/connection/DefaultMongoClientFactory.java
@@ -58,12 +58,12 @@ public final class DefaultMongoClientFactory implements MongoClientFactory {
       return false;
     }
     final DefaultMongoClientFactory that = (DefaultMongoClientFactory) o;
-    return config.equals(that.config);
+    return config.getConnectionString().equals(that.config.getConnectionString());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(config);
+    return Objects.hash(config.getConnectionString());
   }
 
   private static MongoDriverInformation generateMongoDriverInformation(final String configType) {


### PR DESCRIPTION
Spark pushes down aggregation pipelines in the configuration when acquiring MongoClient instances. This change modifies the MongoClientFactory to only take the connection into account for lookups in MongoClientCache.

Without this change different queries against the same MongoDB database result in multiple MongoClient instances preventing caching in those scenarios.

SPARK-441