### PR TITLE
Prefer mongodb.keep_alive_ms over spark.mongodb.keep_alive_ms property

### DIFF
--- a/src/test/java/com/mongodb/spark/sql/connector/connection/LazyMongoClientCacheTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/connection/LazyMongoClientCacheTest.java
@@ -1,0 +1,65 @@
+package com.mongodb.spark.sql.connector.connection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LazyMongoClientCacheTest {
+
+  private String legacyPropertyValue;
+  private String propertyValue;
+
+  @BeforeEach
+  void saveSystemProperties() {
+    legacyPropertyValue =
+        System.getProperty(LazyMongoClientCache.LEGACY_SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY);
+    propertyValue =
+        System.getProperty(LazyMongoClientCache.SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY);
+  }
+
+  @AfterEach
+  void restoreSystemProperties() {
+    System.setProperty(
+        LazyMongoClientCache.LEGACY_SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY,
+        (legacyPropertyValue != null) ? legacyPropertyValue : "");
+    System.setProperty(
+        LazyMongoClientCache.SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY,
+        (propertyValue != null) ? propertyValue : "");
+  }
+
+  @Test
+  void computeKeepAliveUsesDefaultIfPropertiesNotSet() {
+    System.setProperty(LazyMongoClientCache.LEGACY_SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "");
+    System.setProperty(LazyMongoClientCache.SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "");
+
+    assertEquals(5000, LazyMongoClientCache.computeKeepAlive(5000));
+  }
+
+  @Test
+  void computeKeepAliveUsesLegacySystemProperty() {
+    System.setProperty(
+        LazyMongoClientCache.LEGACY_SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "123");
+    System.setProperty(LazyMongoClientCache.SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "");
+
+    assertEquals(123, LazyMongoClientCache.computeKeepAlive(5000));
+  }
+
+  @Test
+  void computeKeepAliveUsesMongoSystemProperty() {
+    System.setProperty(LazyMongoClientCache.LEGACY_SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "");
+    System.setProperty(LazyMongoClientCache.SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "123");
+
+    assertEquals(123, LazyMongoClientCache.computeKeepAlive(5000));
+  }
+
+  @Test
+  void computeKeepAlivePrefersMongoSystemProperty() {
+    System.setProperty(
+        LazyMongoClientCache.LEGACY_SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "456");
+    System.setProperty(LazyMongoClientCache.SYSTEM_MONGO_CACHE_KEEP_ALIVE_MS_PROPERTY, "123");
+
+    assertEquals(123, LazyMongoClientCache.computeKeepAlive(5000));
+  }
+}


### PR DESCRIPTION
The documentation at https://www.mongodb.com/docs/spark-connector/master/faq/ specifies to set mongodb.keep_alive_ms but in the code the system property is prefixed with spark. This changes makes the code consistent with the documentation while maintaining backwards compatibility.

When attempting to set this with
--conf spark.executor.extraJavaOptions="-Dspark.mongodb.keep_alive_ms=70000" an exception occurs since Spark does not allow setting spark flags with that mechanism on executors:

 java.lang.Exception: spark.executor.extraJavaOptions is not allowed to set Spark
 options (was '-Dspark.mongodb.keep_alive_ms=70000’). Set them directly on a
 SparkConf or in a properties file when using ./bin/spark-submit.

Work-around: Rather than setting the system property via extraJavaOptions on executors, the environment variable JAVA_TOOL_OPTIONS can be used:

--conf spark.driver.extraJavaOptions=-Dspark.mongodb.keep_alive_ms=70000 --conf spark.executorEnv.JAVA_TOOL_OPTIONS=-Dspark.mongodb.keep_alive_ms=70000