### PR TITLE
Spark 442

### DIFF
--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -149,6 +149,9 @@ public final class AutoBucketPartitioner implements Partitioner {
       return SINGLE_PARTITIONER.generatePartitions(readConfig);
     }
 
+    double avgObjSizeInBytes = PartitionerHelper.averageDocumentSize(storageStats);
+    double numDocumentsPerPartition = Math.floor(partitionSizeInBytes / avgObjSizeInBytes);
+
     BsonDocument usersCollectionFilter =
         PartitionerHelper.matchQuery(readConfig.getAggregationPipeline());
     long count;
@@ -158,9 +161,6 @@ public final class AutoBucketPartitioner implements Partitioner {
       count = readConfig.withCollection(coll -> coll.countDocuments(
           usersCollectionFilter, new CountOptions().comment(readConfig.getComment())));
     }
-
-    double avgObjSizeInBytes = PartitionerHelper.averageDocumentSize(storageStats, count);
-    double numDocumentsPerPartition = Math.floor(partitionSizeInBytes / avgObjSizeInBytes);
 
     if (numDocumentsPerPartition == 0 || numDocumentsPerPartition >= count) {
       LOGGER.info(

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/SamplePartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/SamplePartitioner.java
@@ -18,6 +18,7 @@
 package com.mongodb.spark.sql.connector.read.partitioner;
 
 import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.SINGLE_PARTITIONER;
+import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.matchQuery;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -34,7 +35,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 import org.bson.conversions.Bson;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -105,8 +105,8 @@ public final class SamplePartitioner extends FieldPartitioner {
       count = readConfig.withCollection(coll ->
           coll.countDocuments(matchQuery, new CountOptions().comment(readConfig.getComment())));
     }
-    double avgObjSizeInBytes =
-        storageStats.get("avgObjSize", new BsonInt32(0)).asNumber().doubleValue();
+
+    double avgObjSizeInBytes = PartitionerHelper.averageDocumentSize(storageStats, count);
     double numDocumentsPerPartition = Math.floor(partitionSizeInBytes / avgObjSizeInBytes);
 
     if (numDocumentsPerPartition >= count) {

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/SamplePartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/SamplePartitioner.java
@@ -18,7 +18,6 @@
 package com.mongodb.spark.sql.connector.read.partitioner;
 
 import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.SINGLE_PARTITIONER;
-import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.matchQuery;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -105,8 +104,7 @@ public final class SamplePartitioner extends FieldPartitioner {
       count = readConfig.withCollection(coll ->
           coll.countDocuments(matchQuery, new CountOptions().comment(readConfig.getComment())));
     }
-
-    double avgObjSizeInBytes = PartitionerHelper.averageDocumentSize(storageStats, count);
+    double avgObjSizeInBytes = PartitionerHelper.averageDocumentSize(storageStats);
     double numDocumentsPerPartition = Math.floor(partitionSizeInBytes / avgObjSizeInBytes);
 
     if (numDocumentsPerPartition >= count) {


### PR DESCRIPTION
Simplified approach to #132

Ensures the whole collection count is used when calculating the average size of documents.