### PR TITLE
Updated the default partitioner to the AutoBucketPartitioner

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorTestCase.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorTestCase.java
@@ -101,7 +101,7 @@ public class MongoSparkConnectorTestCase {
     return getMaxWireVersion() >= 12;
   }
 
-  public boolean isAtLeastSevernDotZero() {
+  public boolean isAtLeastSevenDotZero() {
     return getMaxWireVersion() >= 21;
   }
 

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorTestCase.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/mongodb/MongoSparkConnectorTestCase.java
@@ -101,6 +101,10 @@ public class MongoSparkConnectorTestCase {
     return getMaxWireVersion() >= 12;
   }
 
+  public boolean isAtLeastSevernDotZero() {
+    return getMaxWireVersion() >= 21;
+  }
+
   private int getMaxWireVersion() {
     MongoClient mongoClient = HELPER.getMongoClient();
     ClusterType clusterType = mongoClient.getClusterDescription().getType();

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
@@ -49,11 +49,7 @@ public class AutoBucketPartitionerTest extends PartitionerTestCase {
 
   @Override
   List<String> defaultReadConfigOptions() {
-    return asList(
-        ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG,
-        "1",
-        ReadConfig.PARTITIONER_OPTIONS_PREFIX + SamplePartitioner.SAMPLES_PER_PARTITION_CONFIG,
-        "10");
+    return asList(ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG, "1");
   }
 
   @Test

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
@@ -178,7 +178,7 @@ public class AutoBucketPartitionerTest extends PartitionerTestCase {
 
   @Test
   void testUsingCompoundPartitionFieldThatContainsDuplicates() {
-    assumeTrue(isAtLeastSevernDotZero());
+    assumeTrue(isAtLeastSevenDotZero());
     ReadConfig readConfig = createReadConfig(
         "compound", PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG, "pk,dups");
     loadSampleData(250, 10, readConfig);

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitionerTest.java
@@ -49,7 +49,11 @@ public class AutoBucketPartitionerTest extends PartitionerTestCase {
 
   @Override
   List<String> defaultReadConfigOptions() {
-    return asList(ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG, "1");
+    return asList(
+        ReadConfig.PARTITIONER_CONFIG,
+        PARTITIONER.getClass().getName(),
+        ReadConfig.PARTITIONER_OPTIONS_PREFIX + PARTITION_CHUNK_SIZE_MB_CONFIG,
+        "1");
   }
 
   @Test
@@ -174,6 +178,7 @@ public class AutoBucketPartitionerTest extends PartitionerTestCase {
 
   @Test
   void testUsingCompoundPartitionFieldThatContainsDuplicates() {
+    assumeTrue(isAtLeastSevernDotZero());
     ReadConfig readConfig = createReadConfig(
         "compound", PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_LIST_CONFIG, "pk,dups");
     loadSampleData(250, 10, readConfig);

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -69,7 +69,7 @@ public final class ReadConfig extends AbstractMongoConfig {
    * @see #PARTITIONER_CONFIG
    */
   public static final String PARTITIONER_DEFAULT =
-      "com.mongodb.spark.sql.connector.read.partitioner.SamplePartitioner";
+      "com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner";
 
   /**
    * The prefix for specific partitioner based configuration.

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 /**
  * Auto Bucket Partitioner
  *
- * <p>A $sample based partitioner that provides support for all collection types.
+ * <p>A sample based partitioner that provides support for all collection types.
  * Supports partitioning across single or multiple fields, including nested fields.
  *
  * <p>The logic for the partitioner is as follows:</p>

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -101,7 +101,7 @@ public final class AutoBucketPartitioner implements Partitioner {
   private static final String ID = "_id";
   private static final String MIN = "min";
   private static final String MAX = "max";
-  private static final int SEVERN_DOT_ZERO_WIRE_VERSION = 21;
+  private static final int SEVEN_DOT_ZERO_WIRE_VERSION = 21;
 
   public static final String PARTITION_FIELD_LIST_CONFIG = "fieldList";
   private static final List<String> PARTITION_FIELD_LIST_DEFAULT = singletonList(ID);
@@ -196,7 +196,7 @@ public final class AutoBucketPartitioner implements Partitioner {
             .mapToInt(ServerDescription::getMaxWireVersion)
             .max()
             .orElse(0));
-    if (serverMaxWireVersion < SEVERN_DOT_ZERO_WIRE_VERSION) {
+    if (serverMaxWireVersion < SEVEN_DOT_ZERO_WIRE_VERSION) {
       LOGGER.warn(
           "Note: The AutoBucketPartitioner requires MongoDB 7.0 or greater, if the dataset contains documents with duplicated keys.");
     }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/AutoBucketPartitioner.java
@@ -101,7 +101,7 @@ public final class AutoBucketPartitioner implements Partitioner {
   private static final String ID = "_id";
   private static final String MIN = "min";
   private static final String MAX = "max";
-  private static final int SEVEN_DOT_ZERO_WIRE_VERSION = 21;
+  private static final int SEVERN_DOT_ZERO_WIRE_VERSION = 21;
 
   public static final String PARTITION_FIELD_LIST_CONFIG = "fieldList";
   private static final List<String> PARTITION_FIELD_LIST_DEFAULT = singletonList(ID);
@@ -193,10 +193,10 @@ public final class AutoBucketPartitioner implements Partitioner {
 
     Integer serverMaxWireVersion =
         readConfig.withClient(c -> c.getClusterDescription().getServerDescriptions().stream()
-            .map(ServerDescription::getMaxWireVersion)
-            .max(Integer::compare)
+            .mapToInt(ServerDescription::getMaxWireVersion)
+            .max()
             .orElse(0));
-    if (serverMaxWireVersion < SEVEN_DOT_ZERO_WIRE_VERSION) {
+    if (serverMaxWireVersion < SEVERN_DOT_ZERO_WIRE_VERSION) {
       LOGGER.warn(
           "Note: The AutoBucketPartitioner requires MongoDB 7.0 or greater, if the dataset contains documents with duplicated keys.");
     }


### PR DESCRIPTION
It uses the $bucketAuto aggregation stage and works for compound keys as well as single keys.

SPARK-444