### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Listing code owners is required by DRIVERS-3098
+* @mongodb/dbx-java


### PR DESCRIPTION
SPARK-443

examples, other drivers: https://github.com/mongodb/mongo-rust-driver/pull/1359