### PR TITLE
SPARK-461 - Partitioners extending FieldPartitioner do not support nested partition fields

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/PaginateBySizePartitionerTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/PaginateBySizePartitionerTest.java
@@ -147,6 +147,49 @@ public class PaginateBySizePartitionerTest extends PartitionerTestCase {
   }
 
   @Test
+  void testUsingAlternativeNestedPartitionField() {
+    ReadConfig readConfig = createReadConfig(
+        "altNestedPartitionFiled",
+        PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_CONFIG,
+        "nested.pk");
+    loadComplexSampleData(51, 5, readConfig);
+
+    List<MongoInputPartition> expectedPartitions = asList(
+        new MongoInputPartition(
+            0,
+            createPartitionPipeline(
+                BsonDocument.parse("{'nested.pk': {$lt: '_10010'}}"), emptyList()),
+            getPreferredLocations()),
+        new MongoInputPartition(
+            1,
+            createPartitionPipeline(
+                BsonDocument.parse("{'nested.pk': {$gte: '_10010', $lt: '_10020'}}"), emptyList()),
+            getPreferredLocations()),
+        new MongoInputPartition(
+            2,
+            createPartitionPipeline(
+                BsonDocument.parse("{'nested.pk': {$gte: '_10020', $lt: '_10030'}}"), emptyList()),
+            getPreferredLocations()),
+        new MongoInputPartition(
+            3,
+            createPartitionPipeline(
+                BsonDocument.parse("{'nested.pk': {$gte: '_10030', $lt: '_10040'}}"), emptyList()),
+            getPreferredLocations()),
+        new MongoInputPartition(
+            4,
+            createPartitionPipeline(
+                BsonDocument.parse("{'nested.pk': {$gte: '_10040', $lt: '_10050'}}"), emptyList()),
+            getPreferredLocations()),
+        new MongoInputPartition(
+            5,
+            createPartitionPipeline(
+                BsonDocument.parse("{'nested.pk': {$gte: '_10050'}}"), emptyList()),
+            getPreferredLocations()));
+
+    assertPartitioner(PARTITIONER, expectedPartitions, readConfig);
+  }
+
+  @Test
   void testUsingPartitionFieldThatContainsDuplicates() {
     ReadConfig readConfig =
         createReadConfig("dups", PARTITIONER_OPTIONS_PREFIX + PARTITION_FIELD_CONFIG, "dups");

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/FieldPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/FieldPartitioner.java
@@ -65,6 +65,8 @@ abstract class FieldPartitioner implements Partitioner {
       final List<BsonDocument> upperBounds,
       final ReadConfig readConfig) {
 
+    ValueLoader valueLoader = new ValueLoader(partitionField);
+
     Set<BsonDocument> upperBoundSet = new HashSet<>(upperBounds);
     if (upperBounds.size() != upperBoundSet.size()) {
       throw new ConfigException(format(
@@ -82,7 +84,7 @@ abstract class FieldPartitioner implements Partitioner {
 
           BsonDocument matchFilter = new BsonDocument();
           if (previous != null) {
-            matchFilter.put(partitionField, new BsonDocument("$gte", previous.get(partitionField)));
+            matchFilter.put(partitionField, new BsonDocument("$gte", valueLoader.apply(previous)));
           }
 
           if (current != null) {
@@ -90,7 +92,7 @@ abstract class FieldPartitioner implements Partitioner {
                 partitionField,
                 matchFilter
                     .getDocument(partitionField, new BsonDocument())
-                    .append("$lt", current.get(partitionField)));
+                    .append("$lt", valueLoader.apply(current)));
           }
 
           return new MongoInputPartition(

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/PaginatePartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/PaginatePartitioner.java
@@ -25,6 +25,7 @@ import com.mongodb.spark.sql.connector.read.MongoInputPartition;
 import java.util.ArrayList;
 import java.util.List;
 import org.bson.BsonDocument;
+import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -78,6 +79,7 @@ abstract class PaginatePartitioner extends FieldPartitioner {
       final long count,
       final int numDocumentsPerPartition,
       final ReadConfig readConfig) {
+    ValueLoader valueLoader = new ValueLoader(partitionField);
 
     // Calculate partition ranges
     int numberOfPartitions = (int) Math.ceil(count / (double) numDocumentsPerPartition);
@@ -99,8 +101,9 @@ abstract class PaginatePartitioner extends FieldPartitioner {
         if (!upperBounds.isEmpty()) {
           BsonDocument previous = upperBounds.get(upperBounds.size() - 1);
           BsonDocument matchFilter = new BsonDocument();
-          if (previous.containsKey(partitionField)) {
-            matchFilter.put(partitionField, new BsonDocument("$gte", previous.get(partitionField)));
+          BsonValue value = valueLoader.apply(previous);
+          if (value != null) {
+            matchFilter.put(partitionField, new BsonDocument("$gte", value));
           }
           boundaryPipeline.add(Aggregates.match(matchFilter));
         }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/ValueLoader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/ValueLoader.java
@@ -1,0 +1,64 @@
+package com.mongodb.spark.sql.connector.read.partitioner;
+
+import java.util.function.Function;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+/**
+ * Allows loading values from nested documents if the partition field is a dotted path.
+ * For example, if the partition field is `a.b.c`, this will attempt to load the value from the nested document `a.b` and return the value of `c`.
+ * If the path does not exist or if any part of the path is an array, it will fall back to the original behavior of loading the value from the top-level document using the full partition field as the key.
+ */
+class ValueLoader implements Function<BsonDocument, BsonValue> {
+  private static final char DOT = '.';
+  private static final String DOT_REGEX = "\\.";
+  private final String[] path;
+  private final String partitionField;
+
+  ValueLoader(final String partitionField) {
+    this.partitionField = partitionField;
+    this.path = getPartitionField(partitionField);
+  }
+
+  /**
+   * partitionField.split("\\.") should switch to fastpath non-regex split.
+   */
+  private static String[] getPartitionField(String partitionField) {
+    try {
+      return partitionField.indexOf(DOT) > 0
+          ? partitionField.split(DOT_REGEX)
+          : new String[] {partitionField};
+    } catch (Exception e) {
+      return new String[] {partitionField};
+    }
+  }
+
+  @Override
+  public BsonValue apply(final BsonDocument bsonDocument) {
+    BsonDocument currentDocument = bsonDocument;
+    for (int i = 0; i < path.length; i++) {
+      String field = path[i];
+      if (!currentDocument.containsKey(field)) {
+        break;
+      }
+      BsonValue value = currentDocument.get(field);
+      // If we hit an array at any point, we cannot traverse further; fall back.
+      if (value.isArray()) {
+        break;
+      }
+      // If this is the last segment of the path, return the value directly.
+      if (i == path.length - 1) {
+        return value;
+      }
+      // For non-terminal segments, we must traverse into nested documents.
+      if (value.isDocument()) {
+        currentDocument = value.asDocument();
+      } else {
+        // Non-document encountered before the last segment; fall back.
+        break;
+      }
+    }
+    // fall back to the original behavior: look up the full partition field at the top level
+    return bsonDocument.get(partitionField);
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/ValueLoader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/ValueLoader.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.mongodb.spark.sql.connector.read.partitioner;
 
 import java.util.function.Function;
@@ -6,8 +23,13 @@ import org.bson.BsonValue;
 
 /**
  * Allows loading values from nested documents if the partition field is a dotted path.
- * For example, if the partition field is `a.b.c`, this will attempt to load the value from the nested document `a.b` and return the value of `c`.
- * If the path does not exist or if any part of the path is an array, it will fall back to the original behavior of loading the value from the top-level document using the full partition field as the key.
+ *
+ * <p>For example, if the partition field is {@code a.b.c}, this will attempt to load the value
+ * from the nested document {@code a.b} and return the value of {@code c}.
+ *
+ * <p>If the path does not exist or if any part of the path is an array, it will fall back to the
+ * original behavior of loading the value from the top-level document using the full partition field
+ * as the key.
  */
 class ValueLoader implements Function<BsonDocument, BsonValue> {
   private static final char DOT = '.';
@@ -23,7 +45,7 @@ class ValueLoader implements Function<BsonDocument, BsonValue> {
   /**
    * partitionField.split("\\.") should switch to fastpath non-regex split.
    */
-  private static String[] getPartitionField(String partitionField) {
+  private static String[] getPartitionField(final String partitionField) {
     try {
       return partitionField.indexOf(DOT) > 0
           ? partitionField.split(DOT_REGEX)

--- a/src/test/java/com/mongodb/spark/sql/connector/read/partitioner/ValueLoaderTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/read/partitioner/ValueLoaderTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.spark.sql.connector.read.partitioner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.junit.jupiter.api.Test;
+
+class ValueLoaderTest {
+
+  @Test
+  void loadsSingleLevelFieldValue() {
+    ValueLoader loader = new ValueLoader("_id");
+    BsonDocument document = new BsonDocument("_id", new BsonInt32(42));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(42), result);
+  }
+
+  @Test
+  void loadsNestedFieldValueWithDottedPath() {
+    ValueLoader loader = new ValueLoader("a.b.c");
+    BsonDocument document = new BsonDocument()
+        .append(
+            "a",
+            new BsonDocument().append("b", new BsonDocument().append("c", new BsonInt32(100))));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(100), result);
+  }
+
+  @Test
+  void loadsNestedFieldValueWithTwoLevelPath() {
+    ValueLoader loader = new ValueLoader("user.name");
+    BsonDocument document = new BsonDocument()
+        .append("user", new BsonDocument().append("name", new BsonString("John")));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonString("John"), result);
+  }
+
+  @Test
+  void fallsBackToTopLevelWhenPathDoesNotExist() {
+    ValueLoader loader = new ValueLoader("nested.field");
+    BsonDocument document = new BsonDocument("nested.field", new BsonInt32(50));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(50), result);
+  }
+
+  @Test
+  void fallsBackToTopLevelWhenIntermediatePathMissing() {
+    ValueLoader loader = new ValueLoader("a.b.c");
+    BsonDocument document = new BsonDocument("a.b.c", new BsonInt32(75));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(75), result);
+  }
+
+  @Test
+  void fallsBackToTopLevelWhenArrayEncounteredInPath() {
+    ValueLoader loader = new ValueLoader("a.b.c");
+    BsonDocument document =
+        new BsonDocument().append("a", new BsonArray()).append("a.b.c", new BsonInt32(99));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(99), result);
+  }
+
+  @Test
+  void fallsBackToTopLevelWhenNonDocumentEncounteredBeforeFinalSegment() {
+    ValueLoader loader = new ValueLoader("a.b.c");
+    BsonDocument document = new BsonDocument()
+        .append("a", new BsonString("not a document"))
+        .append("a.b.c", new BsonInt32(88));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(88), result);
+  }
+
+  @Test
+  void returnsNullWhenFieldNotFoundAndNoFallback() {
+    ValueLoader loader = new ValueLoader("missing");
+    BsonDocument document = new BsonDocument("_id", new BsonInt32(1));
+
+    BsonValue result = loader.apply(document);
+
+    assertNull(result);
+  }
+
+  @Test
+  void returnsNullWhenNestedFieldNotFoundAndNoFallback() {
+    ValueLoader loader = new ValueLoader("a.b.c");
+    BsonDocument document = new BsonDocument("a", new BsonDocument("b", new BsonDocument()));
+
+    BsonValue result = loader.apply(document);
+
+    assertNull(result);
+  }
+
+  @Test
+  void handlesEmptyDocument() {
+    ValueLoader loader = new ValueLoader("field");
+    BsonDocument document = new BsonDocument();
+
+    BsonValue result = loader.apply(document);
+
+    assertNull(result);
+  }
+
+  @Test
+  void handlesDottedPathWithOnlyDot() {
+    ValueLoader loader = new ValueLoader(".");
+    BsonDocument document = new BsonDocument(".", new BsonInt32(42));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(42), result);
+  }
+
+  @Test
+  void loadsDeepNestedField() {
+    ValueLoader loader = new ValueLoader("a.b.c.d.e");
+    BsonDocument document = new BsonDocument()
+        .append(
+            "a",
+            new BsonDocument()
+                .append(
+                    "b",
+                    new BsonDocument()
+                        .append(
+                            "c",
+                            new BsonDocument()
+                                .append(
+                                    "d",
+                                    new BsonDocument()
+                                        .append("e", new BsonString("deep value"))))));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonString("deep value"), result);
+  }
+
+  @Test
+  void loadsValueWhenArrayIsAtFinalSegment() {
+    ValueLoader loader = new ValueLoader("items");
+    BsonArray arrayValue = new BsonArray();
+    arrayValue.add(new BsonInt32(1));
+    arrayValue.add(new BsonInt32(2));
+    BsonDocument document = new BsonDocument("items", arrayValue);
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(arrayValue, result);
+  }
+
+  @Test
+  void fallsBackWhenArrayEncounteredInIntermediatePath() {
+    ValueLoader loader = new ValueLoader("a.items.value");
+    BsonArray arrayValue = new BsonArray();
+    arrayValue.add(new BsonInt32(1));
+    BsonDocument document = new BsonDocument()
+        .append("a", new BsonDocument().append("items", arrayValue))
+        .append("a.items.value", new BsonInt32(42));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(42), result);
+  }
+
+  @Test
+  void loadsValueWithMultipleSiblingFields() {
+    ValueLoader loader = new ValueLoader("data.value");
+    BsonDocument document = new BsonDocument()
+        .append(
+            "data",
+            new BsonDocument()
+                .append("value", new BsonInt32(123))
+                .append("other", new BsonInt32(456)))
+        .append("name", new BsonString("test"));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(123), result);
+  }
+
+  @Test
+  void loadsValueWhenPathSegmentIsZeroLength() {
+    ValueLoader loader = new ValueLoader("a..b");
+    BsonDocument document = new BsonDocument("a..b", new BsonInt32(77));
+
+    BsonValue result = loader.apply(document);
+
+    // Should fall back to top-level lookup
+    assertEquals(new BsonInt32(77), result);
+  }
+
+  @Test
+  void loadsIntegerValueFromNestedPath() {
+    ValueLoader loader = new ValueLoader("metadata.count");
+    BsonDocument document = new BsonDocument()
+        .append("metadata", new BsonDocument().append("count", new BsonInt32(999)));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonInt32(999), result);
+  }
+
+  @Test
+  void fallsBackToTopLevelWhenFirstSegmentNotFound() {
+    ValueLoader loader = new ValueLoader("missing.field.path");
+    BsonDocument document = new BsonDocument("missing.field.path", new BsonString("fallback"));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonString("fallback"), result);
+  }
+
+  @Test
+  void handlesSingleFieldWithoutDots() {
+    ValueLoader loader = new ValueLoader("simpleField");
+    BsonDocument document = new BsonDocument("simpleField", new BsonString("simple value"));
+
+    BsonValue result = loader.apply(document);
+
+    assertEquals(new BsonString("simple value"), result);
+  }
+}


### PR DESCRIPTION
A simple valued loader class added for BsonDocument to read values from nested fields.