### PR TITLE
Add rate limiting support for micro batch streaming via maxRows

### DIFF
--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/AbstractMongoStreamTest.java
@@ -96,10 +96,7 @@ import org.opentest4j.AssertionFailedError;
  * return immediately perhaps waiting for the stream to complete.
  */
 abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
-  /*
-   *
-   */
-  private static final String MEMORY = "memory";
+  static final String MEMORY = "memory";
 
   /*
    * The MongoDB sink is only used to test streaming writes.
@@ -111,6 +108,15 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
   abstract Trigger getTrigger();
 
   private String testIdentifier;
+
+  public String getTestIdentifier() {
+    return testIdentifier;
+  }
+
+  public AbstractMongoStreamTest setTestIdentifier(final String testIdentifier) {
+    this.testIdentifier = testIdentifier;
+    return this;
+  }
 
   @ParameterizedTest
   @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
@@ -759,7 +765,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
 
   private static final StructType IGNORE_SCHEMA = createStructType(emptyList());
 
-  private static final StructType DEFAULT_SCHEMA = createStructType(asList(
+  static final StructType DEFAULT_SCHEMA = createStructType(asList(
       createStructField("operationType", DataTypes.StringType, false),
       createStructField("clusterTime", DataTypes.StringType, false),
       createStructField("fullDocument", DataTypes.StringType, true)));
@@ -812,7 +818,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
   }
 
   @SafeVarargs
-  private final void testStreamingQuery(
+  final void testStreamingQuery(
       final String writeFormat,
       final MongoConfig mongoConfig,
       final StructType schema,
@@ -944,7 +950,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     }
   }
 
-  private Consumer<MongoConfig> withSource(
+  Consumer<MongoConfig> withSource(
       @Nullable final String msg,
       final BiConsumer<String, MongoCollection<BsonDocument>> biConsumer) {
     return mongoConfig -> {
@@ -987,7 +993,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     };
   }
 
-  private Consumer<MongoConfig> withMemorySink(
+  Consumer<MongoConfig> withMemorySink(
       final String msg, final BiConsumer<String, Dataset<Row>> biConsumer) {
     return mongoConfig -> {
       LOGGER.info("<- With memory sink: " + msg);
@@ -995,7 +1001,7 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     };
   }
 
-  private MongoConfig createMongoConfig(final CollectionsConfig.Type collectionsConfigType) {
+  MongoConfig createMongoConfig(final CollectionsConfig.Type collectionsConfigType) {
     Map<String, String> options = new HashMap<>();
     Arrays.stream(getSparkConf().getAllWithPrefix(MongoConfig.PREFIX))
         .forEach(t -> options.put(MongoConfig.PREFIX + t._1(), t._2()));
@@ -1022,16 +1028,16 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     return MongoConfig.createConfig(options);
   }
 
-  private static String computeTestIdentifier(
+  static String computeTestIdentifier(
       final String testIdentifierStart, final CollectionsConfig.Type collectionsConfigType) {
     return testIdentifierStart + "_" + collectionsConfigType;
   }
 
-  private String collectionName() {
+  String collectionName() {
     return collectionPrefix() + "Source" + testIdentifier;
   }
 
-  private List<BsonDocument> createDocuments(final int startInclusive, final int endExclusive) {
+  List<BsonDocument> createDocuments(final int startInclusive, final int endExclusive) {
     return createDocuments(
         startInclusive,
         endExclusive,
@@ -1065,13 +1071,19 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
       BsonDocument.parse("{_id: 4, name: 'Timothy Berners-Lee', address: {street: null}}")));
 
   static class StreamingEventsListener extends StreamingQueryListener {
+    private final List<Long> batchInputRows = new ArrayList<>();
     private QueryTerminatedEvent queryTerminatedEvent;
 
     @Override
     public void onQueryStarted(final QueryStartedEvent event) {}
 
     @Override
-    public void onQueryProgress(final QueryProgressEvent event) {}
+    public void onQueryProgress(final QueryProgressEvent event) {
+      long numInputRows = event.progress().numInputRows();
+      if (numInputRows > 0) {
+        batchInputRows.add(numInputRows);
+      }
+    }
 
     @Override
     public void onQueryTerminated(final QueryTerminatedEvent event) {
@@ -1081,6 +1093,10 @@ abstract class AbstractMongoStreamTest extends MongoSparkConnectorTestCase {
     @Nullable
     public QueryTerminatedEvent getQueryTerminatedEvent() {
       return queryTerminatedEvent;
+    }
+
+    public List<Long> getBatchInputRows() {
+      return unmodifiableList(batchInputRows);
     }
   }
 }

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStreamTest.java
@@ -16,7 +16,19 @@
  */
 package com.mongodb.spark.sql.connector.read;
 
+import static com.mongodb.spark.sql.connector.config.MongoConfig.READ_PREFIX;
+import static com.mongodb.spark.sql.connector.config.ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.mongodb.spark.sql.connector.config.CollectionsConfig;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
+import java.util.List;
 import org.apache.spark.sql.streaming.Trigger;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class MongoMicroBatchStreamTest extends AbstractMongoStreamTest {
 
@@ -28,5 +40,45 @@ public class MongoMicroBatchStreamTest extends AbstractMongoStreamTest {
   @Override
   Trigger getTrigger() {
     return Trigger.ProcessingTime("5 seconds");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamBatchMaxRows(final String collectionsConfigModeStr) {
+    assumeTrue(supportsChangeStreams());
+
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    setTestIdentifier(computeTestIdentifier("BatchMaxRows", collectionsConfigType));
+
+    int maxRows = 10;
+    StreamingEventsListener listener = new StreamingEventsListener();
+
+    MongoConfig mongoConfig = createMongoConfig(collectionsConfigType)
+        .withOption(READ_PREFIX + STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, String.valueOf(maxRows));
+    testStreamingQuery(
+        MEMORY,
+        mongoConfig,
+        DEFAULT_SCHEMA,
+        null,
+        listener,
+        withSource("inserting 0-25", (msg, coll) -> coll.insertMany(createDocuments(0, 25))),
+        withMemorySink(
+            "Expected to see 25 documents",
+            (msg, ds) -> assertEquals(25, ds.collectAsList().size(), msg)),
+        withSource("inserting 100-125", (msg, coll) -> coll.insertMany(createDocuments(100, 125))),
+        withMemorySink(
+            "Expecting to see 50 documents",
+            (msg, ds) -> assertEquals(50, ds.collectAsList().size(), msg)));
+
+    List<Long> batchSizes = listener.getBatchInputRows();
+    assertFalse(batchSizes.isEmpty(), "Expected at least one batch with input rows");
+    for (long batchSize : batchSizes) {
+      assertTrue(
+          batchSize <= maxRows,
+          String.format(
+              "Batch had %d input rows, exceeding maxRows=%d. All batches: %s",
+              batchSize, maxRows, batchSizes));
+    }
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/MongoConfig.java
@@ -30,6 +30,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.write.WriteBuilder;
@@ -333,6 +335,28 @@ public interface MongoConfig extends Serializable {
   }
 
   /**
+   * Returns the value to which the specified key is mapped, or {@code defaultValue} if this config
+   * contains no mapping for the key. The value is validated using the provided predicate.
+   *
+   * @param key the key whose associated value is to be returned
+   * @param defaultValue the default mapping for the config
+   * @param validator the predicate to validate the value
+   * @param errorMessage a function that accepts the resolved value and returns the error message if
+   *     validation fails
+   * @return the string value to which the specified key is mapped, or {@code defaultValue} if there
+   *     is no mapping for the key. The key match is case-insensitive.
+   * @throws ConfigException if validation fails
+   */
+  default String getOrDefault(
+      final String key,
+      final String defaultValue,
+      final Predicate<String> validator,
+      final Function<String, String> errorMessage) {
+    String value = getOrDefault(key, defaultValue);
+    return Assertions.validateConfig(value, validator, () -> errorMessage.apply(value));
+  }
+
+  /**
    * Returns the boolean value to which the specified key is mapped, or {@code defaultValue} if
    * there is no mapping for the key.
    *
@@ -376,6 +400,29 @@ public interface MongoConfig extends Serializable {
   }
 
   /**
+   * Returns the int value to which the specified key is mapped, or {@code defaultValue} if there is
+   * no mapping for the key. The value is validated using the provided predicate.
+   *
+   * @param key the key whose associated value is to be returned
+   * @param defaultValue the default mapping for the config
+   * @param validator the predicate to validate the value
+   * @param errorMessage a function that accepts the resolved value and returns the error message if
+   *     validation fails
+   * @return the integer value to which the specified key is mapped, or {@code defaultValue} if
+   *     there is no mapping for the key. The key match is case-insensitive.
+   * @throws ConfigException if the specified key cannot be converted into a valid int or if
+   *     validation fails
+   */
+  default int getInt(
+      final String key,
+      final int defaultValue,
+      final Predicate<Integer> validator,
+      final Function<Integer, String> errorMessage) {
+    int value = getInt(key, defaultValue);
+    return Assertions.validateConfig(value, validator, () -> errorMessage.apply(value));
+  }
+
+  /**
    * Returns the long value to which the specified key is mapped, or {@code defaultValue} if there
    * is no mapping for the key.
    *
@@ -392,6 +439,29 @@ public interface MongoConfig extends Serializable {
         : Assertions.validateConfig(
             () -> Long.parseLong(value),
             () -> format("%s did not contain a valid long, got: %s", key, value));
+  }
+
+  /**
+   * Returns the long value to which the specified key is mapped, or {@code defaultValue} if there
+   * is no mapping for the key. The value is validated using the provided predicate.
+   *
+   * @param key the key whose associated value is to be returned
+   * @param defaultValue the default mapping for the config
+   * @param validator the predicate to validate the value
+   * @param errorMessage a function that accepts the resolved value and returns the error message if
+   *     validation fails
+   * @return the long value to which the specified key is mapped, or {@code defaultValue} if there
+   *     is no mapping for the key. The key match is case-insensitive.
+   * @throws ConfigException if the specified key cannot be converted into a valid long or if
+   *     validation fails
+   */
+  default long getLong(
+      final String key,
+      final long defaultValue,
+      final Predicate<Long> validator,
+      final Function<Long, String> errorMessage) {
+    long value = getLong(key, defaultValue);
+    return Assertions.validateConfig(value, validator, () -> errorMessage.apply(value));
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java
@@ -349,6 +349,10 @@ public final class ReadConfig extends AbstractMongoConfig {
    *   <li>'timestamp' actuates 'change.stream.startup.mode.timestamp.*' properties." If no such
    *       properties are configured, then 'timestamp' is equivalent to 'latest'.
    * </ul>
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value STREAMING_STARTUP_MODE_DEFAULT}
    */
   public static final String STREAMING_STARTUP_MODE_CONFIG = "change.stream.startup.mode";
 
@@ -371,6 +375,8 @@ public final class ReadConfig extends AbstractMongoConfig {
    *
    * <p>See <a
    * href="https://www.mongodb.com/docs/current/reference/operator/aggregation/changeStream">changeStreams</a>.
+   *
+   * <p>Configuration: {@value}
    */
   public static final String STREAMING_STARTUP_MODE_TIMESTAMP_START_AT_OPERATION_TIME_CONFIG =
       "change.stream.startup.mode.timestamp.start.at.operation.time";
@@ -386,19 +392,60 @@ public final class ReadConfig extends AbstractMongoConfig {
    *
    * <p>Actuated only if using micro batch streams.
    *
-   * <p>Default: {@value STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_DEFAULT}
-   *
    * <p>Warning: Splitting up into multiple partitions, removes any guarantees of processing the
    * change events in as happens order. Therefore, care should be taken to ensure partitioning and
    * processing won't cause data inconsistencies downstream.
    *
    * <p>See <a href="https://www.mongodb.com/docs/manual/reference/bson-types/#timestamps">bson
    * timestamp</a>.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_DEFAULT}
    */
   public static final String STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG =
       "change.stream.micro.batch.max.partition.count";
 
   static final int STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_DEFAULT = 1;
+
+  /**
+   * Configures the maximum number of rows per micro batch.
+   *
+   * <p>Provides an alternative for time based micro partitions, useful for extremely high volume collections.
+   *
+   * <p>Actuated only if using micro batch streams.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: As many rows as possible (Long.MAX_VALUE).
+   */
+  public static final String STREAM_MICRO_BATCH_MAX_ROWS_CONFIG =
+      "change.stream.micro.batch.max.rows";
+
+  static final long STREAM_MICRO_BATCH_MAX_ROWS_DEFAULT = Long.MAX_VALUE;
+
+  /**
+   * Configures the name of the sidecar collection used to persist resume tokens when
+   * {@value STREAM_MICRO_BATCH_MAX_ROWS_CONFIG} is set.
+   *
+   * <p>The sidecar collection is created in the source database and stores resume tokens
+   * that allow the Executor to communicate its actual stop position back to the Driver
+   * between micro batches. Each stream instance is scoped by a hash of the checkpoint
+   * location, which prevents collisions when multiple streams read from the same database.
+   *
+   * <p>This configuration is useful when the connector's MongoDB user does not have
+   * permission to create collections, allowing a DBA to pre-create the collection and
+   * grant access.
+   *
+   * <p>Configuration: {@value}
+   *
+   * <p>Default: {@value STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_DEFAULT}
+   */
+  public static final String STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_CONFIG =
+      "change.stream.micro.batch.max.rows.offset.collection";
+
+  static final String STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_DEFAULT =
+      "__spark_resume_tokens";
 
   /**
    * Output extended JSON for any String types.
@@ -584,7 +631,39 @@ public final class ReadConfig extends AbstractMongoConfig {
   public int getMicroBatchMaxPartitionCount() {
     return getInt(
         STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG,
-        STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_DEFAULT);
+        STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_DEFAULT,
+        v -> v > 0,
+        v -> format(
+            "'%s' must be a positive integer, got: %d",
+            STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, v));
+  }
+
+  /** @return the micro batch max rows */
+  public long getMicroBatchMaxRows() {
+    long value = getLong(
+        STREAM_MICRO_BATCH_MAX_ROWS_CONFIG,
+        STREAM_MICRO_BATCH_MAX_ROWS_DEFAULT,
+        v -> v > 0,
+        v ->
+            format("'%s' must be a positive long, got: %d", STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, v));
+    if (value < Long.MAX_VALUE && getMicroBatchMaxPartitionCount() != 1) {
+      throw new ConfigException(format(
+          "'%s' requires '%s' to be 1, got: %d",
+          STREAM_MICRO_BATCH_MAX_ROWS_CONFIG,
+          STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG,
+          getMicroBatchMaxPartitionCount()));
+    }
+    return value;
+  }
+
+  /** @return the micro batch max rows offset collection name */
+  public String getMicroBatchMaxRowsOffsetCollection() {
+    return getOrDefault(
+        STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_CONFIG,
+        STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_DEFAULT,
+        v -> !v.trim().isEmpty(),
+        v ->
+            format("'%s' must not be empty", STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_CONFIG));
   }
 
   /**

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MicroBatchResumeTokenStore.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MicroBatchResumeTokenStore.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.mongodb.spark.sql.connector.read;
+
+import static java.lang.String.format;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.Sorts;
+import com.mongodb.spark.sql.connector.config.ReadConfig;
+import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
+import java.io.Serializable;
+import java.util.Optional;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+
+/**
+ * Manages resume token persistence in a sidecar collection.
+ *
+ * <p>Only instantiated when {@code ReadLimit.maxRows(n)} is configured.
+ * The sidecar collection acts as a communication channel between the Executor
+ * (which writes the last-seen resume token) and the Driver (which reads it
+ * to determine the starting offset for the next micro batch).
+ *
+ * <p>All documents are scoped by a {@code checkpointHash} derived from the
+ * checkpoint location, which prevents collisions when multiple streams read
+ * from the same database and share the same sidecar collection.
+ */
+final class MicroBatchResumeTokenStore implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private static final String RESUME_TOKEN_FIELD = "resumeToken";
+  private static final String PARTITION_ID_FIELD = "partitionId";
+  private static final String CHECKPOINT_HASH_FIELD = "checkpointHash";
+  private static final String TIMESTAMP_FIELD = "updatedAt";
+
+  private final ReadConfig readConfig;
+  private final String collectionName;
+  private final String checkpointHash;
+
+  MicroBatchResumeTokenStore(final ReadConfig readConfig, final String checkpointLocation) {
+    this.readConfig = readConfig;
+    this.collectionName = readConfig.getMicroBatchMaxRowsOffsetCollection();
+    this.checkpointHash = Integer.toHexString(checkpointLocation.hashCode());
+  }
+
+  String getCollectionName() {
+    return collectionName;
+  }
+
+  void storeResumeToken(final int partitionId, final BsonDocument resumeToken) {
+    try {
+      getCollection()
+          .replaceOne(
+              Filters.and(
+                  Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash),
+                  Filters.eq(PARTITION_ID_FIELD, partitionId)),
+              new BsonDocument()
+                  .append(CHECKPOINT_HASH_FIELD, new BsonString(checkpointHash))
+                  .append(PARTITION_ID_FIELD, new BsonInt32(partitionId))
+                  .append(RESUME_TOKEN_FIELD, resumeToken)
+                  .append(TIMESTAMP_FIELD, new BsonDateTime(System.currentTimeMillis())),
+              new ReplaceOptions().upsert(true));
+    } catch (RuntimeException e) {
+      throw new MongoSparkException(
+          format(
+              "Failed to persist resume token for partition %d. Ensure the user has permissions to read / write to '%s.%s'",
+              partitionId, readConfig.getDatabaseName(), collectionName),
+          e);
+    }
+  }
+
+  Optional<BsonDocument> getLatestResumeToken() {
+    BsonDocument result = null;
+    try {
+      result = getCollection()
+          .find(Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash))
+          .sort(Sorts.descending(TIMESTAMP_FIELD))
+          .first();
+    } catch (RuntimeException e) {
+      throw new MongoSparkException(
+          format(
+              "Failed to get latest resume token. Ensure the user has permissions to read / write to '%s.%s'",
+              readConfig.getDatabaseName(), collectionName),
+          e);
+    }
+    if (result == null) {
+      return Optional.empty();
+    }
+    return Optional.of(result.getDocument(RESUME_TOKEN_FIELD));
+  }
+
+  void cleanup() {
+    try {
+      getCollection().deleteMany(Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash));
+    } catch (RuntimeException e) {
+      throw new MongoSparkException(
+          format(
+              "Failed to cleanup data from '%s.%s'. All fields matching: {\"%s\": %s} can be removed.",
+              readConfig.getDatabaseName(), collectionName, CHECKPOINT_HASH_FIELD, checkpointHash),
+          e);
+    }
+  }
+
+  private MongoCollection<BsonDocument> getCollection() {
+    return readConfig
+        .getMongoClient()
+        .getDatabase(readConfig.getDatabaseName())
+        .getCollection(collectionName, BsonDocument.class);
+  }
+}

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MicroBatchResumeTokenStore.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MicroBatchResumeTokenStore.java
@@ -18,6 +18,7 @@ package com.mongodb.spark.sql.connector.read;
 
 import static java.lang.String.format;
 
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.ReplaceOptions;
@@ -26,6 +27,8 @@ import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -58,7 +61,7 @@ final class MicroBatchResumeTokenStore implements Serializable {
   MicroBatchResumeTokenStore(final ReadConfig readConfig, final String checkpointLocation) {
     this.readConfig = readConfig;
     this.collectionName = readConfig.getMicroBatchMaxRowsOffsetCollection();
-    this.checkpointHash = Integer.toHexString(checkpointLocation.hashCode());
+    this.checkpointHash = Long.toHexString(hash64(checkpointLocation));
   }
 
   String getCollectionName() {
@@ -66,41 +69,30 @@ final class MicroBatchResumeTokenStore implements Serializable {
   }
 
   void storeResumeToken(final int partitionId, final BsonDocument resumeToken) {
-    try {
-      getCollection()
-          .replaceOne(
-              Filters.and(
-                  Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash),
-                  Filters.eq(PARTITION_ID_FIELD, partitionId)),
-              new BsonDocument()
-                  .append(CHECKPOINT_HASH_FIELD, new BsonString(checkpointHash))
-                  .append(PARTITION_ID_FIELD, new BsonInt32(partitionId))
-                  .append(RESUME_TOKEN_FIELD, resumeToken)
-                  .append(TIMESTAMP_FIELD, new BsonDateTime(System.currentTimeMillis())),
-              new ReplaceOptions().upsert(true));
-    } catch (RuntimeException e) {
-      throw new MongoSparkException(
-          format(
-              "Failed to persist resume token for partition %d. Ensure the user has permissions to read / write to '%s.%s'",
-              partitionId, readConfig.getDatabaseName(), collectionName),
-          e);
-    }
+    withCollection(
+        coll -> coll.replaceOne(
+            Filters.and(
+                Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash),
+                Filters.eq(PARTITION_ID_FIELD, partitionId)),
+            new BsonDocument()
+                .append(CHECKPOINT_HASH_FIELD, new BsonString(checkpointHash))
+                .append(PARTITION_ID_FIELD, new BsonInt32(partitionId))
+                .append(RESUME_TOKEN_FIELD, resumeToken)
+                .append(TIMESTAMP_FIELD, new BsonDateTime(System.currentTimeMillis())),
+            new ReplaceOptions().upsert(true)),
+        () -> format(
+            "Failed to persist resume token for partition %d. Ensure the user has permissions to read / write to '%s.%s'",
+            partitionId, readConfig.getDatabaseName(), collectionName));
   }
 
   Optional<BsonDocument> getLatestResumeToken() {
-    BsonDocument result = null;
-    try {
-      result = getCollection()
-          .find(Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash))
-          .sort(Sorts.descending(TIMESTAMP_FIELD))
-          .first();
-    } catch (RuntimeException e) {
-      throw new MongoSparkException(
-          format(
-              "Failed to get latest resume token. Ensure the user has permissions to read / write to '%s.%s'",
-              readConfig.getDatabaseName(), collectionName),
-          e);
-    }
+    BsonDocument result = withCollection(
+        coll -> coll.find(Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash))
+            .sort(Sorts.descending(TIMESTAMP_FIELD))
+            .first(),
+        () -> format(
+            "Failed to get latest resume token. Ensure the user has permissions to read / write to '%s.%s'",
+            readConfig.getDatabaseName(), collectionName));
     if (result == null) {
       return Optional.empty();
     }
@@ -108,21 +100,33 @@ final class MicroBatchResumeTokenStore implements Serializable {
   }
 
   void cleanup() {
-    try {
-      getCollection().deleteMany(Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash));
+    withCollection(
+        coll -> coll.deleteMany(Filters.eq(CHECKPOINT_HASH_FIELD, checkpointHash)),
+        () -> format(
+            "Failed to cleanup data from '%s.%s'. All fields matching: {\"%s\": %s} can be removed.",
+            readConfig.getDatabaseName(), collectionName, CHECKPOINT_HASH_FIELD, checkpointHash));
+  }
+
+  private <T> T withCollection(
+      final Function<MongoCollection<BsonDocument>, T> function,
+      final Supplier<String> exceptionMessageSupplier) {
+    try (MongoClient client = readConfig.getMongoClient()) {
+      return function.apply(client
+          .getDatabase(readConfig.getDatabaseName())
+          .getCollection(getCollectionName(), BsonDocument.class));
     } catch (RuntimeException e) {
-      throw new MongoSparkException(
-          format(
-              "Failed to cleanup data from '%s.%s'. All fields matching: {\"%s\": %s} can be removed.",
-              readConfig.getDatabaseName(), collectionName, CHECKPOINT_HASH_FIELD, checkpointHash),
-          e);
+      throw new MongoSparkException(exceptionMessageSupplier.get(), e);
     }
   }
 
-  private MongoCollection<BsonDocument> getCollection() {
-    return readConfig
-        .getMongoClient()
-        .getDatabase(readConfig.getDatabaseName())
-        .getCollection(collectionName, BsonDocument.class);
+  /** FNV-1a 64-bit hash. */
+  private static long hash64(final String input) {
+    long fnvPrime = 0x100000001b3L;
+    long hash = 0xcbf29ce484222325L; // FNV offset basis 64-bit
+    for (int i = 0; i < input.length(); i++) {
+      hash ^= input.charAt(i);
+      hash *= fnvPrime;
+    }
+    return hash;
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
@@ -54,6 +54,10 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
   private final BsonDocumentToRowConverter bsonDocumentToRowConverter;
   private final ReadConfig readConfig;
   private final MongoClient mongoClient;
+  private final MicroBatchResumeTokenStore resumeTokenStore;
+  private final boolean rateLimited;
+  private long batchMaxRows;
+  private BsonDocument lastResumeToken;
   private volatile boolean closed = false;
   private MongoChangeStreamCursor<BsonDocument> changeStreamCursor;
   private InternalRow currentRow;
@@ -69,12 +73,16 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
   MongoMicroBatchPartitionReader(
       final MongoMicroBatchInputPartition partition,
       final BsonDocumentToRowConverter bsonDocumentToRowConverter,
-      final ReadConfig readConfig) {
+      final ReadConfig readConfig,
+      final MicroBatchResumeTokenStore resumeTokenStore) {
 
     this.partition = partition;
     this.bsonDocumentToRowConverter = bsonDocumentToRowConverter;
     this.readConfig = readConfig;
     this.mongoClient = readConfig.getMongoClient();
+    this.batchMaxRows = readConfig.getMicroBatchMaxRows();
+    this.resumeTokenStore = resumeTokenStore;
+    this.rateLimited = resumeTokenStore != null;
     LOGGER.info(
         "Creating partition reader for: PartitionId: {} with Schema: {}",
         partition.getPartitionId(),
@@ -102,10 +110,18 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
     BsonDocument next;
 
     do {
+      if (batchMaxRows <= 0) {
+        break;
+      }
+
       try {
         currentRow = null;
         next = cursor.tryNext();
         if (next != null) {
+          if (rateLimited) {
+            lastResumeToken = cursor.getResumeToken();
+          }
+
           if (readConfig.streamPublishFullDocumentOnly()) {
             next = next.getDocument(FULL_DOCUMENT, new BsonDocument());
           }
@@ -115,6 +131,7 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
               bsonDocumentToRowConverter.toInternalRow(next);
           if (internalRowOptional.isPresent()) {
             currentRow = internalRowOptional.get();
+            batchMaxRows--;
             return true;
           }
         }
@@ -139,6 +156,11 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
   public void close() {
     if (!closed) {
       closed = true;
+
+      if (rateLimited && lastResumeToken != null) {
+        resumeTokenStore.storeResumeToken(partition.getPartitionId(), lastResumeToken);
+      }
+
       if (changeStreamCursor != null) {
         LOGGER.debug("Closing cursor for partitionId: {}", partition.getPartitionId());
         try {
@@ -169,11 +191,16 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
       List<BsonDocument> pipeline = new ArrayList<>();
       pipeline.add(Aggregates.match(Filters.lt("clusterTime", partition.getEndOffsetTimestamp()))
           .toBsonDocument());
+      if (rateLimited) {
+        pipeline.add(Aggregates.match(Filters.ne("ns.coll", resumeTokenStore.getCollectionName()))
+            .toBsonDocument());
+      }
       if (readConfig.streamPublishFullDocumentOnly()) {
         pipeline.add(Aggregates.match(Filters.exists(FULL_DOCUMENT)).toBsonDocument());
       }
       pipeline.addAll(partition.getPipeline());
       ChangeStreamIterable<Document> changeStreamIterable;
+
       if (readConfig.getCollectionsConfig().getType() == CollectionsConfig.Type.SINGLE) {
         changeStreamIterable = mongoClient
             .getDatabase(readConfig.getDatabaseName())
@@ -187,7 +214,15 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
           .fullDocument(readConfig.getStreamFullDocument())
           .fullDocumentBeforeChange(readConfig.getStreamFullDocumentBeforeChange())
           .comment(readConfig.getComment());
-      if (partition.getStartOffsetTimestamp().getTime() >= 0) {
+
+      if (rateLimited) {
+        Optional<BsonDocument> savedResumeToken = resumeTokenStore.getLatestResumeToken();
+        if (savedResumeToken.isPresent()) {
+          changeStreamIterable.startAfter(savedResumeToken.get());
+        } else if (partition.getStartOffsetTimestamp().getTime() >= 0) {
+          changeStreamIterable.startAtOperationTime(partition.getStartOffsetTimestamp());
+        }
+      } else if (partition.getStartOffsetTimestamp().getTime() >= 0) {
         changeStreamIterable.startAtOperationTime(partition.getStartOffsetTimestamp());
       }
 

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
@@ -157,22 +157,23 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
   public void close() {
     if (!closed) {
       closed = true;
-
-      if (rateLimited && lastResumeToken != null) {
-        resumeTokenStore.storeResumeToken(partition.getPartitionId(), lastResumeToken);
+      try {
+          if (rateLimited && lastResumeToken != null) {
+              resumeTokenStore.storeResumeToken(partition.getPartitionId(), lastResumeToken);
+          }
+      } finally {
+          if (changeStreamCursor != null) {
+              LOGGER.debug("Closing cursor for partitionId: {}", partition.getPartitionId());
+              try {
+                  changeStreamCursor.close();
+              } catch (Exception e) {
+                  // Ignore
+              } finally {
+                  changeStreamCursor = null;
+              }
+          }
+          mongoClient.close();
       }
-
-      if (changeStreamCursor != null) {
-        LOGGER.debug("Closing cursor for partitionId: {}", partition.getPartitionId());
-        try {
-          changeStreamCursor.close();
-        } catch (Exception e) {
-          // Ignore
-        } finally {
-          changeStreamCursor = null;
-        }
-      }
-      mongoClient.close();
     }
   }
 

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReader.java
@@ -69,6 +69,7 @@ final class MongoMicroBatchPartitionReader implements PartitionReader<InternalRo
    * @param bsonDocumentToRowConverter the converter from {@link BsonDocument} to {@link
    *     InternalRow}
    * @param readConfig the read configuration for reading from the partition
+   * @param resumeTokenStore the resume token store when limiting responses using max rows.
    */
   MongoMicroBatchPartitionReader(
       final MongoMicroBatchInputPartition partition,

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReaderFactory.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchPartitionReaderFactory.java
@@ -33,17 +33,22 @@ final class MongoMicroBatchPartitionReaderFactory implements PartitionReaderFact
   private static final long serialVersionUID = 1L;
   private final BsonDocumentToRowConverter bsonDocumentToRowConverter;
   private final ReadConfig readConfig;
+  private final MicroBatchResumeTokenStore resumeTokenStore;
 
   /**
    * Construct a new instance
    *
    * @param bsonDocumentToRowConverter the bson document to internal row converter
    * @param readConfig the read configuration
+   * @param resumeTokenStore the resume token store, or null if rate limiting is not enabled
    */
   MongoMicroBatchPartitionReaderFactory(
-      final BsonDocumentToRowConverter bsonDocumentToRowConverter, final ReadConfig readConfig) {
+      final BsonDocumentToRowConverter bsonDocumentToRowConverter,
+      final ReadConfig readConfig,
+      final MicroBatchResumeTokenStore resumeTokenStore) {
     this.bsonDocumentToRowConverter = bsonDocumentToRowConverter;
     this.readConfig = readConfig;
+    this.resumeTokenStore = resumeTokenStore;
   }
 
   @Override
@@ -54,6 +59,9 @@ final class MongoMicroBatchPartitionReaderFactory implements PartitionReaderFact
             "Unsupported InputPartition type, a MongoMicroBatchInputPartition instance is required. Got: %s",
             partition.getClass()));
     return new MongoMicroBatchPartitionReader(
-        (MongoMicroBatchInputPartition) partition, bsonDocumentToRowConverter, readConfig);
+        (MongoMicroBatchInputPartition) partition,
+        bsonDocumentToRowConverter,
+        readConfig,
+        resumeTokenStore);
   }
 }

--- a/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStream.java
@@ -23,11 +23,15 @@ import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.schema.BsonDocumentToRowConverter;
 import com.mongodb.spark.sql.connector.schema.InferSchema;
 import java.time.Instant;
+import java.util.Optional;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.connector.read.streaming.ReadLimit;
+import org.apache.spark.sql.connector.read.streaming.SupportsAdmissionControl;
 import org.apache.spark.sql.types.StructType;
+import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,13 +47,16 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Uses seconds since epoch offsets to create boundaries between partitions.
  */
-final class MongoMicroBatchStream implements MicroBatchStream {
+final class MongoMicroBatchStream implements SupportsAdmissionControl, MicroBatchStream {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MongoMicroBatchStream.class);
   private final StructType schema;
   private final MongoOffsetStore mongoOffsetStore;
   private final ReadConfig readConfig;
   private final BsonDocumentToRowConverter bsonDocumentToRowConverter;
+  private final long batchMaxRows;
+  private final boolean rateLimited;
+  private final MicroBatchResumeTokenStore resumeTokenStore;
   private volatile Long lastTime = Instant.now().getEpochSecond();
 
   /**
@@ -71,26 +78,36 @@ final class MongoMicroBatchStream implements MicroBatchStream {
         new MongoOffsetStore(checkpointLocation, MongoOffset.getInitialOffset(readConfig));
     this.readConfig = readConfig;
     this.bsonDocumentToRowConverter = new BsonDocumentToRowConverter(schema, readConfig);
+    this.batchMaxRows = readConfig.getMicroBatchMaxRows();
+    this.rateLimited = batchMaxRows > 0 && batchMaxRows < Long.MAX_VALUE;
+
+    if (rateLimited) {
+      this.resumeTokenStore = new MicroBatchResumeTokenStore(readConfig, checkpointLocation);
+    } else {
+      this.resumeTokenStore = null;
+    }
+  }
+
+  MicroBatchResumeTokenStore getResumeTokenStore() {
+    return resumeTokenStore;
   }
 
   @Override
   public Offset latestOffset() {
-    long now = Instant.now().getEpochSecond();
-    if (lastTime < now) {
-      lastTime = now;
-    }
-    return new BsonTimestampOffset(new BsonTimestamp(lastTime.intValue(), 0));
+    return computeLatestOffset();
   }
 
   @Override
   public InputPartition[] planInputPartitions(final Offset start, final Offset end) {
+    LOGGER.debug("MicroBatchStream plan: {} - {}", start, end);
     return generateMicroBatchPartitions(
         schema, readConfig, (BsonTimestampOffset) start, (BsonTimestampOffset) end);
   }
 
   @Override
   public PartitionReaderFactory createReaderFactory() {
-    return new MongoMicroBatchPartitionReaderFactory(bsonDocumentToRowConverter, readConfig);
+    return new MongoMicroBatchPartitionReaderFactory(
+        bsonDocumentToRowConverter, readConfig, resumeTokenStore);
   }
 
   @Override
@@ -105,12 +122,48 @@ final class MongoMicroBatchStream implements MicroBatchStream {
 
   @Override
   public void commit(final Offset end) {
-    LOGGER.info("MicroBatchStream commit: {}", end);
+    LOGGER.debug("MicroBatchStream commit: {}", end);
     mongoOffsetStore.updateOffset((MongoOffset) end);
   }
 
   @Override
   public void stop() {
     LOGGER.info("MicroBatchStream stopped.");
+    if (resumeTokenStore != null) {
+      resumeTokenStore.cleanup();
+    }
+  }
+
+  @Override
+  public ReadLimit getDefaultReadLimit() {
+    if (rateLimited) {
+      return ReadLimit.maxRows(batchMaxRows);
+    }
+    return ReadLimit.allAvailable();
+  }
+
+  @Override
+  public Offset latestOffset(final Offset startOffset, final ReadLimit limit) {
+    return computeLatestOffset();
+  }
+
+  private Offset computeLatestOffset() {
+    long now = Instant.now().getEpochSecond();
+    if (lastTime < now) {
+      lastTime = now;
+    }
+    return new BsonTimestampOffset(new BsonTimestamp(lastTime.intValue(), 0));
+  }
+
+  @Override
+  public Offset reportLatestOffset() {
+    if (resumeTokenStore != null) {
+      Optional<BsonDocument> resumeToken = resumeTokenStore.getLatestResumeToken();
+      if (resumeToken.isPresent()) {
+        return new ResumeTokenBasedOffset(resumeToken.get());
+      }
+    }
+    long now = Instant.now().getEpochSecond();
+    return new BsonTimestampOffset(new BsonTimestamp((int) now, 0));
   }
 }

--- a/src/test/java/com/mongodb/spark/sql/connector/config/MongoConfigTest.java
+++ b/src/test/java/com/mongodb/spark/sql/connector/config/MongoConfigTest.java
@@ -462,6 +462,95 @@ public class MongoConfigTest {
     assertThrows(ConfigException.class, () -> mongoConfig.getDouble("string", 1.0));
   }
 
+  @Test
+  void testReadConfigMicroBatchMaxPartitionCount() {
+    ReadConfig readConfig = MongoConfig.readConfig(CONFIG_MAP);
+
+    // Default
+    assertEquals(1, readConfig.getMicroBatchMaxPartitionCount());
+
+    // Custom value
+    readConfig =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, "4");
+    assertEquals(4, readConfig.getMicroBatchMaxPartitionCount());
+
+    // Non-numeric value
+    ReadConfig nonNumeric =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, "abc");
+    assertThrows(ConfigException.class, nonNumeric::getMicroBatchMaxPartitionCount);
+
+    // Negative value
+    ReadConfig negative =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, "-1");
+    assertThrows(ConfigException.class, negative::getMicroBatchMaxPartitionCount);
+
+    // Zero value
+    ReadConfig zero =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, "0");
+    assertThrows(ConfigException.class, zero::getMicroBatchMaxPartitionCount);
+  }
+
+  @Test
+  void testReadConfigMicroBatchMaxRows() {
+    ReadConfig readConfig = MongoConfig.readConfig(CONFIG_MAP);
+
+    // Default
+    assertEquals(Long.MAX_VALUE, readConfig.getMicroBatchMaxRows());
+
+    // Custom value
+    readConfig = readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, "100");
+    assertEquals(100L, readConfig.getMicroBatchMaxRows());
+
+    // Single partition is fine
+    ReadConfig singlePartition = readConfig
+        .withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, "100")
+        .withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, "1");
+    assertEquals(100L, singlePartition.getMicroBatchMaxRows());
+
+    // Non-numeric value
+    ReadConfig nonNumeric =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, "abc");
+    assertThrows(ConfigException.class, nonNumeric::getMicroBatchMaxRows);
+
+    // Negative value
+    ReadConfig negative =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, "-1");
+    assertThrows(ConfigException.class, negative::getMicroBatchMaxRows);
+
+    // Zero value
+    ReadConfig zero = readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, "0");
+    assertThrows(ConfigException.class, zero::getMicroBatchMaxRows);
+
+    // Requires single partition
+    ReadConfig multiPartition = readConfig
+        .withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, "100")
+        .withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_PARTITION_COUNT_CONFIG, "4");
+    assertThrows(ConfigException.class, multiPartition::getMicroBatchMaxRows);
+  }
+
+  @Test
+  void testReadConfigMicroBatchMaxRowsOffsetCollection() {
+    ReadConfig readConfig = MongoConfig.readConfig(CONFIG_MAP);
+
+    // Default
+    assertEquals("__spark_resume_tokens", readConfig.getMicroBatchMaxRowsOffsetCollection());
+
+    // Custom value
+    readConfig = readConfig.withOption(
+        ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_CONFIG, "my_resume_tokens");
+    assertEquals("my_resume_tokens", readConfig.getMicroBatchMaxRowsOffsetCollection());
+
+    // Empty string
+    ReadConfig empty =
+        readConfig.withOption(ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_CONFIG, "");
+    assertThrows(ConfigException.class, empty::getMicroBatchMaxRowsOffsetCollection);
+
+    // Whitespace only
+    ReadConfig whitespace = readConfig.withOption(
+        ReadConfig.STREAM_MICRO_BATCH_MAX_ROWS_OFFSET_COLLECTION_CONFIG, "   ");
+    assertThrows(ConfigException.class, whitespace::getMicroBatchMaxRowsOffsetCollection);
+  }
+
   private static Stream<MongoConfig> optionsMapConfigs() {
     MongoConfig simpleMongoConfig = MongoConfig.createConfig(OPTIONS_CONFIG_MAP);
     return Stream.of(simpleMongoConfig.toReadConfig(), simpleMongoConfig.toWriteConfig());


### PR DESCRIPTION
Implements `SupportsAdmissionControl` to limit the number of change stream events consumed per micro batch when `max.rows` is configured.

When rate limiting is active, a `MicroBatchResumeTokenStore` persists resume tokens to a shared sidecar collection so the executor can communicate its actual stop position back to the driver for accurate resumption. Documents are scoped by a `checkpointHash` field derived from the checkpoint location, preventing collisions when multiple streams share the same database. The sidecar collection is only created and used when `max.rows` is set; on stop, only rows for the current stream are cleaned up.

Configuration:
- `change.stream.micro.batch.max.rows` 
   Default: unlimited (Long.MAX_VALUE) — uses time between batches.
- `change.stream.micro.batch.max.rows.offset.collection` 
   Default: `__spark_resume_tokens` — only used when `max.rows` is set.

Note: Rate limiting requires `change.stream.micro.batch.max.partition.count` to be 1 and write access to the sidecar collection in the source database.

SPARK-456