### PR TITLE
SPARK-466 - #155

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
-version = "11.1.0"
+version = "11.2.0-SNAPSHOT"
 group = "org.mongodb.spark"
 
 description = "The official MongoDB Apache Spark Connect Connector."

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStreamTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/MongoMicroBatchStreamTest.java
@@ -26,7 +26,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import com.mongodb.spark.sql.connector.config.CollectionsConfig;
 import com.mongodb.spark.sql.connector.config.MongoConfig;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.streaming.Trigger;
+import org.bson.BsonDocument;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -80,5 +85,53 @@ public class MongoMicroBatchStreamTest extends AbstractMongoStreamTest {
               "Batch had %d input rows, exceeding maxRows=%d. All batches: %s",
               batchSize, maxRows, batchSizes));
     }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"SINGLE", "MULTIPLE", "ALL"})
+  void testStreamBatchMaxRowsNoLossOrDuplicates(final String collectionsConfigModeStr) {
+    assumeTrue(supportsChangeStreams());
+
+    CollectionsConfig.Type collectionsConfigType =
+        CollectionsConfig.Type.valueOf(collectionsConfigModeStr);
+    setTestIdentifier(computeTestIdentifier("BatchMaxRowsNoDups", collectionsConfigType));
+
+    int maxRows = 49;
+    int totalDocs = 50;
+    String testId = getTestIdentifier();
+
+    Set<String> expectedIds =
+        IntStream.range(0, totalDocs).mapToObj(i -> testId + "-" + i).collect(Collectors.toSet());
+
+    MongoConfig mongoConfig = createMongoConfig(collectionsConfigType)
+        .withOption(READ_PREFIX + STREAM_MICRO_BATCH_MAX_ROWS_CONFIG, String.valueOf(maxRows));
+    testStreamingQuery(
+        MEMORY,
+        mongoConfig,
+        DEFAULT_SCHEMA,
+        null,
+        null,
+        withSource(
+            "inserting 0-" + totalDocs,
+            (msg, coll) -> coll.insertMany(createDocuments(0, totalDocs))),
+        withMemorySink(
+            "All " + totalDocs + " documents should arrive with no duplicates", (msg, ds) -> {
+              List<Row> rows = ds.collectAsList();
+              assertEquals(totalDocs, rows.size(), msg + " — wrong total count");
+
+              Set<String> actualIds = rows.stream()
+                  .map(r -> r.getString(r.fieldIndex("fullDocument")))
+                  .map(json -> BsonDocument.parse(json).getString("_id").getValue())
+                  .collect(Collectors.toSet());
+
+              assertEquals(
+                  totalDocs,
+                  actualIds.size(),
+                  String.format(
+                      "%s — found %d unique IDs out of %d rows (duplicates detected)",
+                      msg, actualIds.size(), rows.size()));
+
+              assertEquals(expectedIds, actualIds, msg + " — missing or unexpected document IDs");
+            }));
   }
 }

--- a/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/ShardedPartitionerTest.java
+++ b/src/integrationTest/java/com/mongodb/spark/sql/connector/read/partitioner/ShardedPartitionerTest.java
@@ -17,6 +17,7 @@
 
 package com.mongodb.spark.sql.connector.read.partitioner;
 
+import static com.mongodb.spark.sql.connector.config.ReadConfig.PARTITIONER_OPTIONS_PREFIX;
 import static com.mongodb.spark.sql.connector.read.partitioner.PartitionerHelper.SINGLE_PARTITIONER;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -24,6 +25,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -32,6 +34,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import com.mongodb.spark.sql.connector.read.MongoInputPartition;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.bson.BsonDocument;
@@ -66,6 +69,56 @@ public class ShardedPartitionerTest extends PartitionerTestCase {
     loadSampleData(100, 10, readConfig);
 
     assertPartitioner(readConfig);
+  }
+
+  @Test
+  void testShufflesPartitionsWhenEnabled() {
+    assumeTrue(isSharded());
+    ReadConfig readConfig = createReadConfig("shuffle");
+    shardCollection(readConfig.getNamespace(), "{_id: 1}");
+    loadSampleData(100, 10, readConfig);
+
+    List<MongoInputPartition> ordered = PARTITIONER.generatePartitions(readConfig);
+    assumeTrue(ordered.size() > 1, "Shuffling requires more than one partition to be observable");
+
+    List<MongoInputPartition> shuffled = PARTITIONER.generatePartitions(readConfig.withOption(
+        PARTITIONER_OPTIONS_PREFIX + ShardedPartitioner.SHUFFLE_CONFIG, "true"));
+
+    // The same partitions are produced, just in a different order.
+    assertEquals(new HashSet<>(ordered), new HashSet<>(shuffled));
+    assertNotEquals(ordered, shuffled);
+  }
+
+  @Test
+  void testShufflingWithASeedIsDeterministic() {
+    assumeTrue(isSharded());
+    ReadConfig readConfig = createReadConfig(
+        "shuffleSeed",
+        PARTITIONER_OPTIONS_PREFIX + ShardedPartitioner.SHUFFLE_CONFIG,
+        "true",
+        PARTITIONER_OPTIONS_PREFIX + ShardedPartitioner.SHUFFLE_SEED_CONFIG,
+        "42");
+    shardCollection(readConfig.getNamespace(), "{_id: 1}");
+    loadSampleData(100, 10, readConfig);
+
+    List<MongoInputPartition> firstRun = PARTITIONER.generatePartitions(readConfig);
+    List<MongoInputPartition> secondRun = PARTITIONER.generatePartitions(readConfig);
+    assertEquals(firstRun, secondRun);
+  }
+
+  @Test
+  void testThrowsExceptionWithAnInvalidShuffleSeed() {
+    assumeTrue(isSharded());
+    ReadConfig readConfig = createReadConfig(
+        "shuffleInvalidSeed",
+        PARTITIONER_OPTIONS_PREFIX + ShardedPartitioner.SHUFFLE_CONFIG,
+        "true",
+        PARTITIONER_OPTIONS_PREFIX + ShardedPartitioner.SHUFFLE_SEED_CONFIG,
+        "not-a-long");
+    shardCollection(readConfig.getNamespace(), "{_id: 1}");
+    loadSampleData(100, 10, readConfig);
+
+    assertThrows(MongoSparkException.class, () -> PARTITIONER.generatePartitions(readConfig));
   }
 
   @Test

--- a/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/ShardedPartitioner.java
+++ b/src/main/java/com/mongodb/spark/sql/connector/read/partitioner/ShardedPartitioner.java
@@ -24,14 +24,17 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
 import com.mongodb.spark.sql.connector.assertions.Assertions;
+import com.mongodb.spark.sql.connector.config.MongoConfig;
 import com.mongodb.spark.sql.connector.config.ReadConfig;
 import com.mongodb.spark.sql.connector.exceptions.MongoSparkException;
 import com.mongodb.spark.sql.connector.read.MongoInputPartition;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.bson.BsonBoolean;
@@ -51,12 +54,30 @@ import org.jetbrains.annotations.VisibleForTesting;
  * <p>Uses the chunks collection and partitions the collection based on the sharded collections
  * chunk ranges.
  *
+ * <p>Generated partitions are ordered by their shard key range, which groups together all the
+ * partitions that belong to the same shard. As Spark schedules tasks in partition order, this can
+ * cause the executors to query a single shard at a time rather than spreading the load across all
+ * shards. The following options can be used to shuffle the partitions so the load is balanced
+ * across shards:
+ *
+ * <ul>
+ *   <li>{@value SHUFFLE_CONFIG}: Shuffle the generated partitions so consecutive partitions are
+ *       unlikely to belong to the same shard. Defaults to: {@value SHUFFLE_DEFAULT}.
+ *   <li>{@value SHUFFLE_SEED_CONFIG}: The seed to use when shuffling the partitions. Set a seed to
+ *       get a reproducible shuffle. Only actuated when {@value SHUFFLE_CONFIG} is {@code true}.
+ *       Defaults to a random seed.
+ * </ul>
+ *
  * <p><strong>Note:</strong> Does not support collections sharded using hashed shard keys or
  * compound shard keys.
  */
 @ApiStatus.Internal
 public final class ShardedPartitioner implements Partitioner {
 
+  private static final boolean SHUFFLE_DEFAULT = false;
+
+  static final String SHUFFLE_SEED_CONFIG = "shuffle.seed";
+  static final String SHUFFLE_CONFIG = "shuffle";
   private static final String CONFIG_DATABASE = "config";
   private static final String CONFIG_COLLECTIONS = "collections";
   private static final String CONFIG_CHUNKS = "chunks";
@@ -132,12 +153,30 @@ public final class ShardedPartitioner implements Partitioner {
           readConfig.getNamespace().getFullName());
       return new SinglePartitionPartitioner().generatePartitions(readConfig);
     }
+
     return partitions;
+  }
+
+  private static Random createShuffleRandom(final MongoConfig partitionerOptions) {
+    // this seed can be used for easier testing and reproducibility of the shuffle
+    final String seed = partitionerOptions.get(SHUFFLE_SEED_CONFIG);
+    if (seed == null) {
+      return new Random();
+    }
+    try {
+      return new Random(Long.parseLong(seed.trim()));
+    } catch (final NumberFormatException e) {
+      throw new MongoSparkException(
+          format("Invalid config: %s must be a valid long, got: %s", SHUFFLE_SEED_CONFIG, seed));
+    }
   }
 
   @NotNull
   private List<MongoInputPartition> createMongoInputPartitions(
       final List<BsonDocument> chunks, final ReadConfig readConfig) {
+    MongoConfig partitionerOptions = readConfig.getPartitionerOptions();
+    boolean shuffle = partitionerOptions.getBoolean(SHUFFLE_CONFIG, SHUFFLE_DEFAULT);
+    Random shuffleRandom = shuffle ? createShuffleRandom(partitionerOptions) : null;
     Map<String, List<String>> shardMap = createShardMap(readConfig);
 
     return IntStream.range(0, chunks.size())
@@ -170,7 +209,12 @@ public final class ShardedPartitioner implements Partitioner {
               shardMap.get(chunkDocument.getString("shard", new BsonString("")).getValue()));
         })
         .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+        .collect(Collectors.collectingAndThen(Collectors.toCollection(ArrayList::new), collected -> {
+          if (shuffle) {
+            Collections.shuffle(collected, shuffleRandom);
+          }
+          return collected;
+        }));
   }
 
   @NotNull


### PR DESCRIPTION
[SPARK-466](https://jira.mongodb.org/browse/SPARK-466) add a setting to shuffle the partition list
Otherwise it's sorted and later on ExecutorService will execute partitions against the same shard
spark.mongodb.read.partitioner.options.shuffle - boolean , When true, shuffles the generated partitions so consecutive partitions are unlikely to belong to the same shard, spreading read load across shards.
spark.mongodb.read.partitioner.options.shuffle.seed - long , The seed used when shuffling partitions. Set it to get a reproducible shuffle. Only takes effect when shuffle is true. An invalid (non-long) value raises a MongoSparkException.